### PR TITLE
airlines: XM added, PQ modified

### DIFF
--- a/opentraveldata/optd_airline_best_known_so_far.csv
+++ b/opentraveldata/optd_airline_best_known_so_far.csv
@@ -52,7 +52,7 @@ air-air-asia-india-v1^^2014-06-12^^^I5^0^AirAsia India^^^^^http://en.wikipedia.o
 air-air-asia-indonesia-v1^^2000-06-22^^AWQ^QZ^975^Indonesia AirAsia^Awair^^^^http://en.wikipedia.org/wiki/Indonesia_AirAsia^en|Indonesia AirAsia|=en|Awair|^^air-air-asia-indonesia^1
 air-air-asia-indonesia-extra-v1^^2014-12-26^^INX^XT^0^^Indonesia AirAsia X^^^^http://en.wikipedia.org/wiki/Indonesia_AirAsia_X^en||=en|Indonesia AirAsia X|^^air-air-asia-indonesia-extra^1
 air-air-asia-japan-v1^^2012-08-01^^WAJ^DJ^0^AirAsia Japan^^^^^http://en.wikipedia.org/wiki/AirAsia_Japan^en|AirAsia Japan|=ja|エアアジア・ジャパン株式会社|=ja|Eāajia Japan Kabushiki-Gaisha|^^air-air-asia-japan^1
-air-air-asia-philippines-v1^^^2010-12-01^APG^PQ^0^Philippines AirAsia^Panafrican^^^^http://en.wikipedia.org/wiki/Philippines_AirAsia^en|Philippines AirAsia|=en|Panafrican|^^air-air-asia-philippines^1
+air-air-asia-philippines-v1^^^^APG^PQ^0^Philippines AirAsia^Panafrican^^^^http://en.wikipedia.org/wiki/Philippines_AirAsia^en|Philippines AirAsia|=en|Panafrican|^^air-air-asia-philippines^1
 air-air-asia-x-v1^^^^XAX^D7^843^AirAsia X^^^^^http://en.wikipedia.org/wiki/AirAsia_X^en|AirAsia X|^^air-air-asia-x^1
 air-air-astana-v1^^2002-05-15^^KZR^KC^465^Air Astana^^^^^http://en.wikipedia.org/wiki/Air_Astana^en|Air Astana|^TSE^air-air-astana^1
 air-air-austral-v1^^1975-01-01^^REU^UU^760^Air Austral^^^^^http://en.wikipedia.org/wiki/Air_Austral^en|Air Austral|^^air-air-austral^1
@@ -172,6 +172,7 @@ air-alaska-seaplane-service-v1^^^^^J5^0^Alaska Seaplane Service^Stock Sochi^^^^^
 air-dart-ltd-v1^^2016-01-01^^LID^D4^443^DART Ltd^^^^^^en|DART Ltd|^IEV^air-dart-ltd^1
 air-alitalia-v1^^1999-03-01^^AZA^AZ^55^Alitalia^Alitalia S.A.I.^^Member^^http://en.wikipedia.org/wiki/Alitalia^en|Alitalia|=en|Alitalia S.A.I.|^^air-alitalia^1
 air-alitalia-cityliner-v1^^2006-06-07^^CYL^CT^0^Alitalia CityLiner^Air One CityLiner^^Affiliate^^http://en.wikipedia.org/wiki/Alitalia_CityLiner^en|Alitalia CityLiner|=en|Air One CityLiner|^^air-alitalia-cityliner^1
+air-alitalia-express-v1^^2009-01-13^2015-02-06^SMX^XM^^Alitalia Express^C.A.I. First^^^^https://en.wikipedia.org/wiki/C.A.I._First^en|Alitalia Express|=en|C.A.I. First|^^air-alitalia-express^1
 air-allegiant-air-v1^^1998-06-01^^AAY^G4^268^Allegiant Air^^^^^http://en.wikipedia.org/wiki/Allegiant_Air^en|Allegiant Air|^^air-allegiant-air^1
 air-alliance-airlines-v1^^^^FWQ^QQ^0^Alliance Airlines^^^^PT^^en|Alliance Airlines|^^air-alliance-airlines^1
 air-all-nippon-airways-v1^^1952-12-27^^ANA^NH^205^All Nippon Airways^ANA^^Member^^http://en.wikipedia.org/wiki/All_Nippon_Airways^en|All Nippon Airways|=en|ANA|^^air-all-nippon-airways^1


### PR DESCRIPTION
PQ - Air Asia Phillipines - last flights published for Dec 2015 but the iata code seems still valid, set validity_to to missing (replacing 2010-12-01 which was incorrect)
XM - Alitalia Express - now integrated into Alitalia but used own code for some time (also called C.A.I. First)