### PR TITLE
fixed details for some airlines (CO,G3,7H,JD)

### DIFF
--- a/opentraveldata/optd_airlines.csv
+++ b/opentraveldata/optd_airlines.csv
@@ -315,7 +315,7 @@ air-batavia-air-v1^1^2002-01-01^2013-01-31^BTV^Y6^0^Batavia Air^^^^^http://en.wi
 air-batik-air-indonesia-v1^^2013-05-03^^BTK^ID^0^Batik Air^^^^P^http://en.wikipedia.org/wiki/Batik_Air^102090^en|Batik Air|^^air-batik-air-indonesia^1
 air-bb-airways-v1^^2012-09-13^^^BO^505^BB Airways^^^^^http://en.wikipedia.org/wiki/BB_Airways^^en|BB Airways|^^air-bb-airways^1
 air-bearskin-airlines-v1^^1963-07-17^^BLS^JV^632^Bearskin Airlines^^^^^http://en.wikipedia.org/wiki/Bearskin_Airlines^14969^en|Bearskin Airlines|^^air-bearskin-airlines^1
-air-beijing-capital-airlines-v1^^2010-05-01^^CBJ^JD^898^Beijing Capital Airlines^^^^^http://en.wikipedia.org/wiki/Beijing_Capital_Airlines^37404^en|Beijing Capital Airlines|p=en|Capital_Airlines|s=en|Deer Jet Airlines|h=en|Deer Air|=pny|Shǒudū Hángkōng|p=pny|Jīnlù Hángkōng|=sign|CAPITAL JET|=zh|首都航空|p=zh|金鹿航空|h^HAK=HGH=PEK=SHE=SYX=XIY^air-beijing-capital-airlines^1
+air-beijing-capital-airlines-v1^^2010-05-04^^CBJ^JD^898^Beijing Capital Airlines^^^^^http://en.wikipedia.org/wiki/Beijing_Capital_Airlines^37404^en|Beijing Capital Airlines|p=en|Capital_Airlines|s=en|Deer Jet Airlines|h=en|Deer Air|=pny|Shǒudū Hángkōng|p=pny|Jīnlù Hángkōng|=sign|CAPITAL JET|=zh|首都航空|p=zh|金鹿航空|h^HAK=HGH=PEK=SHE=SYX=XIY^air-beijing-capital-airlines^1
 air-bek-air-v1^^^^BEK^Z9^183^Jsc Bek Air^^^^^^6744^en|Jsc Bek Air|^^air-bek-air^1
 air-belair-airlines-v1^^^^^4T^0^Belair Airlines^Russian Air^^^^^11254^en|Belair Airlines|=en|Russian Air|^^air-belair-airlines^1
 air-belavia-v1^^1996-03-05^^BRU^B2^628^Belavia^^^^^http://en.wikipedia.org/wiki/Belavia^28737^en|Belavia|^^air-belavia^1
@@ -437,7 +437,7 @@ air-condor-berlin-v1^^^^CIB^DF^0^Condor Berlin^^^^^http://en.wikipedia.org/wiki/
 air-condor-v1^^1956-01-01^^CFG^DE^881^Condor^^^^^http://en.wikipedia.org/wiki/Condor_Flugdienst^36409^en|Condor|^^air-condor^1
 air-congo-airways-v1^^2016-09-01^^CGA^8Z^0^Congo Airways^^^^^http://en.wikipedia.org/wiki/Congo_Airways^^en|Congo Airways|^FIH^air-congo-airways^1
 air-congo-express-v1^1^2010-01-01^2014-01-01^CXR^9X^0^Congo Express^New Axis Air^^^^http://en.wikipedia.org/wiki/Congo_Express^^en|Congo Express|=en|New Axis Air|^^air-congo-express^1
-air-continental-airlines-v1^1^^2010-09-30^COA^CO^5^Continental Airlines^Continental^^^^http://fr.wikipedia.org/wiki/Continental_Airlines^^en|Continental Airlines|=en|Continental|^^air-continental-airlines^1
+air-continental-airlines-v1^1^^2012-03-03^COA^CO^5^Continental Airlines^Continental^^^^http://fr.wikipedia.org/wiki/Continental_Airlines^^en|Continental Airlines|=en|Continental|^^air-continental-airlines^1
 air-continental-micronesia-v1^1^1968-05-16^2010-12-22^CMI^CS^0^Continental Micronesia^^^^^http://en.wikipedia.org/wiki/Continental_Micronesia^^en|Continental Micronesia|^^air-continental-micronesia^1
 air-conviasa-v1^^^^VCV^V0^308^Conviasa^Conviasa^^^^^15146^en|Conviasa|=en|Conviasa|^^air-conviasa^1
 air-copa-airlines-v1^^1947-08-15^^CMP^CM^230^Copa Airlines^Compañía Panameña de Aviación^Star Alliance^Member^^http://en.wikipedia.org/wiki/Copa_Airlines^100213^en|Copa Airlines|=en|Compañía Panameña de Aviación|^^air-copa-airlines^1
@@ -462,7 +462,7 @@ air-danish-air-transport-v1^^1989-01-01^^DTR^DX^243^Danish Air Transport^^^^^htt
 air-dart-ltd-v1^^2016-01-01^^LID^D4^443^DART Ltd^^^^^^178^en|DART Ltd|^IEV^air-dart-ltd^1
 air-darwin-airline-v1^1^^2014-10-31^DWT^0D^779^Darwin Airline^^^^^http://en.wikipedia.org/wiki/Darwin_Airline^^en|Darwin Airline|^^air-darwin-airline^1
 air-dauair-v1^1^2005-01-01^2006-12-31^DAU^D5^0^Dauair^^^^^http://en.wikipedia.org/wiki/Dauair^^en|Dauair|^LBC^air-dauair^1
-air-deer-jet-airlines-v1^1^2006-01-01^2010-05-31^CBJ^JD^0^Deer Jet Airlines^Deer Air^^^^http://en.wikipedia.org/wiki/Beijing_Capital_Airlines^^en|Deer Jet Airlines|=en|Deer Air|^^air-deer-jet-airlines^1
+air-deer-jet-airlines-v1^1^2006-01-01^2010-05-03^CBJ^JD^0^Deer Jet Airlines^Deer Air^^^^http://en.wikipedia.org/wiki/Beijing_Capital_Airlines^^en|Deer Jet Airlines|=en|Deer Air|^^air-deer-jet-airlines^1
 air-delta-air-lines-v1^^1929-06-17^^DAL^DL^6^Delta Air Lines^^Skyteam^Member^^http://en.wikipedia.org/wiki/Delta_Air_Lines^1087213^en|Delta Air Lines|^^air-delta-air-lines^1
 air-delta-connection-v1^^^^DCP^DQ^521^Delta Connection^Coastal Air^^^^^^en|Delta Connection|=en|Coastal Air|^^air-delta-connection^1
 air-delux-public-charter-v1^^2015-01-01^^JSX^XE^0^Delux Public Charter^^^^^^3666^en|Delux Public Charter|^^air-delux-public-charter^1
@@ -516,7 +516,7 @@ air-enkor-jsc-v1^1^1986-01-01^2005-12-31^ENK^H6^0^Enkor^^^^^http://en.wikipedia.
 air-equaflight-service-v1^^^^^E7^965^Equaflight Service^Fly European^^^P^^157^en|Equaflight Service|=en|Fly European|^^air-equaflight-service^1
 air-equatorial-congo-airlines-v1^^2011-09-24^^PTI^LC^753^ECAir^^^^^^^en|Equatorial Congo Airlines|=en|ECAir|ps=ja|エクアトリアル・コンゴ・エアラインズ|^^air-equatorial-congo-airlines^1
 air-era-aviation-v1^1^1948-01-01^2016-06-30^ERH^7H^808^Era Aviation^^^^^http://en.wikipedia.org/wiki/Ravn_Alaska^^en|Ravn Alaska|p=en|Corvus Airlines|=en|Era Aviation|h=sign|Raven Flight|^ANC=FAI^air-era-aviation^1
-air-era-aviation-v2^^2016-07-31^^RVF^7H^808^Ravn Alaska^^^^^http://en.wikipedia.org/wiki/Ravn_Alaska^23834^en|Ravn Alaska|p=en|Corvus Airlines|=en|Era Aviation|h=sign|Raven Flight|^ANC=FAI^air-era-aviation^2
+air-era-aviation-v2^^2016-07-01^^RVF^7H^808^Ravn Alaska^^^^^http://en.wikipedia.org/wiki/Ravn_Alaska^23834^en|Ravn Alaska|p=en|Corvus Airlines|=en|Era Aviation|h=sign|Raven Flight|^ANC=FAI^air-era-aviation^2
 air-eritrean-airlines-v1^^^^ERT^B8^637^Eritrean Airlines^^^^^^425^en|Eritrean Airlines|^^air-eritrean-airlines^1
 air-ero-sun-d-or-v1^^^^ERO^2U^383^Ero Sun D Or^^^^P^^^en|Ero Sun D Or|^^air-ero-sun-d-or^1
 air-e-savtravel-v1^^^^^L1^0^E Savtravel^^^^^^^en|E Savtravel|^^air-e-savtravel^1
@@ -625,8 +625,7 @@ air-go2sky-v1^^2013-02-14^^RLX^6G^0^Go2Sky^^^^^http://en.wikipedia.org/wiki/Go2S
 air-go-airlines-v1^^2005-11-01^^GOW^G8^0^GoAir^^^^^http://en.wikipedia.org/wiki/GoAir^60295^en|GoAir|^BOM=DEL^air-go-airlines^1
 air-gojet-airlines-v1^^2004-01-01^^GJS^G7^573^GoJet Airlines^^^^^http://en.wikipedia.org/wiki/GoJet_Airlines^108772^en|GoJet Airlines|^^air-gojet-airlines^1
 air-golden-myanmar-airlines-v1^^^^^Y5^509^Golden Myanmar Airlines^^^^^^2661^en|Golden Myanmar Airlines|^^air-golden-myanmar-airlines^1
-air-gol-transportes-aereos-v1^1^2001-01-15^2016-04-30^GOL^G3^127^Gol Transportes Aéreos^VRG Linhas Aéreas^^^^http://en.wikipedia.org/wiki/Gol_Transportes_A%C3%A9reos^^en|Gol Transportes Aéreos|p=en|VRG Linhas Aéreas|^^air-gol-transportes-aereos^1
-air-gol-transportes-aereos-v2^^2016-05-01^^GLO^G3^127^Gol Transportes Aéreos^^^^^http://en.wikipedia.org/wiki/Gol_Transportes_A%C3%A9reos^247854^en|Gol Transportes Aéreos|p=en|VRG Linhas Aéreas|=en|Gol Linhas Aéreas Inteligentes|^CGH^air-gol-transportes-aereos^2
+air-gol-transportes-aereos-v1^^2001-01-15^^GLO^G3^127^Gol Transportes Aéreos^^^^^http://en.wikipedia.org/wiki/Gol_Transportes_A%C3%A9reos^247854^en|Gol Transportes Aéreos|p=en|VRG Linhas Aéreas|=en|Gol Linhas Aéreas Inteligentes|^CGH^air-gol-transportes-aereos^1
 air-go-v1^^^^GOE^GO^0^Go^^^^^^^en|Go|^^air-go^1
 air-grand-china-air-v1^^2007-01-01^^GDC^CN^895^Grand China Air^^^^^http://en.wikipedia.org/wiki/Grand_China_Air^3161^abbr|GCA|=en|Grand China Air|=pny|Dà Xīn Huá Hángkōng|=sign|GRAND CHINA|=wuu|大新华航空|=yue|大新華航空|^^air-grand-china-air^1
 air-grant-aviation-v1^^1993-01-01^^SWV^GV^0^Grant Aviation^^^^^http://en.wikipedia.org/wiki/Grant_Aviation^56250^en|Grant Aviation|^AKN=ANC=BET^air-grant-aviation^1


### PR DESCRIPTION
CO - fixed valid_to date
G3 - removed the reference to the false icao code
7H - fixed validity dates (filled the gap), not sure if the dates in 2016 are correct
JD - fixed validity dates (fixed overlap), consider changing IDs (deer jet and beijing capital are same airlines, just re-branded)