### PR TITLE
Several updates of airlines

### DIFF
--- a/opentraveldata/optd_airline_no_longer_valid.csv
+++ b/opentraveldata/optd_airline_no_longer_valid.csv
@@ -172,6 +172,7 @@ air-investavia-v1^1^2007-01-01^2015-06-30^TLG^IV^0^InvestAvia^^^^^^en|InvestAvia
 air-iraqi-airways-v1^1^1946-01-28^2016-05-31^IAW^IA^73^Iraqi Airways^^^^^http://en.wikipedia.org/wiki/Iraqi_Airways^en|Iraqi Airways|^BGW^air-iraqi-airways^1
 air-island-airlines-v1^1^1930-01-01^2015-12-11^ISA^IS^0^Island Airlines^^^^^http://en.wikipedia.org/wiki/Island_Airlines^en|Island Airlines|^^air-island-airlines^1
 air-islas-airways-v1^1^2003-02-01^2012-10-15^ISW^IF^0^Islas Airways^^^^^http://en.wikipedia.org/wiki/Islas_Airways^en|Islas Airways|^^air-islas-airways^1
+air-jal-express-v1^1^1998-07-01^2014-09-30^JC^0^JAL Express^^OneWorld^Affiliate^^http://en.wikipedia.org/wiki/JAL_Express^6777^en|JAL Express|^^air-jal-express^1
 air-karthago-airlines-v1^1^2002-01-01^2010-12-31^KAJ^5R^0^Karthago Airlines^^^^^http://en.wikipedia.org/wiki/Nouvelair^en|Nouvelair|p=en|Karthago Airlines|h^DJE^air-karthago-airlines^1
 air-kartika-airlines-v1^1^2001-05-15^2010-12-31^KAE^3Y^0^Kartika Airlines^^^^^http://en.wikipedia.org/wiki/Kartika_Airlines^en|Kartika Airlines|^HLP^air-kartika-airlines^1
 air-katmai-air-v1^1^^2015-12-31^^KT^0^Katmai Air^^^^^http://www.katmailand.com/air-services^en|Katmai Air|^BKF^air-katmai-air^1

--- a/opentraveldata/optd_airline_no_longer_valid.csv
+++ b/opentraveldata/optd_airline_no_longer_valid.csv
@@ -183,7 +183,7 @@ air-investavia-v1^1^2007-01-01^2015-06-30^TLG^IV^0^InvestAvia^^^^^^en|InvestAvia
 air-iraqi-airways-v1^1^1946-01-28^2016-05-31^IAW^IA^73^Iraqi Airways^^^^^http://en.wikipedia.org/wiki/Iraqi_Airways^en|Iraqi Airways|^BGW^air-iraqi-airways^1
 air-island-airlines-v1^1^1930-01-01^2015-12-11^ISA^IS^0^Island Airlines^^^^^http://en.wikipedia.org/wiki/Island_Airlines^en|Island Airlines|^^air-island-airlines^1
 air-islas-airways-v1^1^2003-02-01^2012-10-15^ISW^IF^0^Islas Airways^^^^^http://en.wikipedia.org/wiki/Islas_Airways^en|Islas Airways|^^air-islas-airways^1
-air-jal-express-v1^1^1998-07-01^2014-09-30^JC^0^JAL Express^^OneWorld^Affiliate^^http://en.wikipedia.org/wiki/JAL_Express^6777^en|JAL Express|^^air-jal-express^1
+air-jal-express-v1^1^1998-07-01^2014-09-30^^JC^0^JAL Express^^OneWorld^Affiliate^^http://en.wikipedia.org/wiki/JAL_Express^6777^en|JAL Express|^^air-jal-express^1
 air-karthago-airlines-v1^1^2002-01-01^2010-12-31^KAJ^5R^0^Karthago Airlines^^^^^http://en.wikipedia.org/wiki/Nouvelair^en|Nouvelair|p=en|Karthago Airlines|h^DJE^air-karthago-airlines^1
 air-kartika-airlines-v1^1^2001-05-15^2010-12-31^KAE^3Y^0^Kartika Airlines^^^^^http://en.wikipedia.org/wiki/Kartika_Airlines^en|Kartika Airlines|^HLP^air-kartika-airlines^1
 air-katmai-air-v1^1^^2015-12-31^^KT^0^Katmai Air^^^^^http://www.katmailand.com/air-services^en|Katmai Air|^BKF^air-katmai-air^1

--- a/opentraveldata/optd_airline_no_longer_valid.csv
+++ b/opentraveldata/optd_airline_no_longer_valid.csv
@@ -48,8 +48,18 @@ air-alpi-eagles-v1^1^1979-01-01^2007-12-31^ELG^E8^0^Alpi Eagles^^^^^http://en.wi
 air-al-naser-airlines-v1^1^2009-02-01^2013-12-31^MHK^6N^503^Al Naser Airlines^^^^^http://en.wikipedia.org/wiki/Al-Naser_Airlines^en|Al Naser Airlines|^^air-al-naser-airlines^1
 air-alajnihah-air-transport-v1^1^^2015-04-01^ANH^2T^311^Alajnihah Airways^^^^^http://en.wikipedia.org/wiki/Alajnihah_Airways^en|Alajnihah Airways|^^air-alajnihah-air-transport^1
 air-alidaunia-v1^1^^2015-12-31^LID^D4^0^Alidaunia^^^^^^en|Alidaunia|^^air-alidaunia^1
-air-amadeus-8z-v1^1^^2014-06-01^^8Z^0^Amadeus 8Z^Amadeus 8Z^^^D^^en|Amadeus 8Z|=en|Amadeus 8Z|^^air-amadeus-8z^1
-air-amadeus-pdf-2d-v1^1^2010-09-01^2010-09-30^^2D^0^Amadeus PDF 2D^^^^D^^en|Amadeus PDF 2D|^^air-amadeus-pdf-2d^1
+air-amadeus-7n-v1^1^2011-01-25^^^7N^^Amadeus 7N^Amadeus 7N^^^D^^4582^en|Amadeus 7N|=en|Amadeus 7N|^^air-amadeus-7n^1
+air-amadeus-8z-v1^1^^2014-06-01^^8Z^0^Amadeus 8Z^Amadeus 8Z^^^D^^^en|Amadeus 8Z|=en|Amadeus 8Z|^^air-amadeus-8z^1
+air-amadeus-eight-v1^1^^^XYD^8X^794^Amadeus Eight^Amadeus Eight^^^D^^^en|Amadeus Eight|=en|Amadeus Eight|^^air-amadeus-eight^1
+air-amadeus-pdf-0e-v1^1^^^XYS^0E^0^Amadeus PDF 0E^^^^D^^^en|Amadeus PDF 0E|^^air-amadeus-pdf-0e^1
+air-amadeus-pdf-2d-v1^1^2010-09-01^2010-09-30^^2D^0^Amadeus PDF 2D^^^^D^^^en|Amadeus PDF 2D|^^air-amadeus-pdf-2d^1
+air-amadeus-pdf-2y-v1^1^^^^2Y^0^Amadeus PDF 2Y^^^^D^^^en|Amadeus PDF 2Y|^^air-amadeus-pdf-2y^1
+air-amadeus-pdf-7s-v1^1^^^XYW^7S^792^Amadeus PDF 7S^Amadeus 7S^^^D^^3140^en|Amadeus PDF 7S|=en|Amadeus 7S|^^air-amadeus-pdf-7s^1
+air-amadeus-pdf-9s-v1^1^^^XYX^9S^793^Amadeus PDF 9S^Amadeus 9S^^^D^^^en|Amadeus PDF 9S|=en|Amadeus 9S|^^air-amadeus-pdf-9s^1
+air-amadeus-pdf-9z-v1^1^^^^9Z^0^Amadeus PDF 9Z^^^^D^^^en|Amadeus PDF 9Z|^^air-amadeus-pdf-9z^1
+air-amadeus-seven-v1^1^^^XYC^7X^791^Amadeus Seven^Amadeus Seven^^^D^^^en|Amadeus Seven|=en|Amadeus Seven|^^air-amadeus-seven^1
+air-amadeus-six-v1^1^^^XYB^6X^172^Amadeus Six^Amadeus Six^^^D^^^en|Amadeus Six|=en|Amadeus Six|^^air-amadeus-six^1
+air-amadeus-two-v1^1^^^XYA^2X^799^Amadeus Two^Amadeus Two^^^D^^^en|Amadeus Two|=en|Amadeus Two|^^air-amadeus-two^1
 air-angkor-airways-v1^1^2007-01-01^2008-12-31^AKW^G6^0^Angkor Airways^^^^^http://en.wikipedia.org/wiki/Angkor_Airways^en|Angkor Airways|^PNH^air-angkor-airways^1
 air-armavia-v1^1^1996-01-01^2013-04-01^RNV^U8^669^Armavia^^^^^http://en.wikipedia.org/wiki/Armavia^en|Armavia|=en|Armenian International Airways|h=hy|Արմավիա|^^air-armavia^1
 air-armenian-international-airways-v1^1^2002-07-12^2004-12-31^RML^MV^0^Armenian International Airways^^^^^http://en.wikipedia.org/wiki/Armenian_International_Airways^en|Armavia|=en|Armenian International Airways|h=hy|Հայկական Միջազգային Ավիաուղիներ|^^air-armenian-international-airways^1

--- a/opentraveldata/optd_airline_no_longer_valid.csv
+++ b/opentraveldata/optd_airline_no_longer_valid.csv
@@ -135,7 +135,7 @@ air-farnair-switzerland-v1^1^1984-01-01^2015-03-01^FAT^FT^0^Farnair Switzerland^
 air-finncomm-airlines-v1^1^1993-01-01^2011-12-31^FCM^FC^216^Finncomm Airlines^^^^^http://en.wikipedia.org/wiki/Finncomm_Airlines^en|Finncomm Airlines|^^air-finncomm-airlines^1
 air-florida-coastal-airlines-v1^1^1995-01-01^2014-06-06^FCL^PA^0^Florida Coastal Airlines^^^^P^http://en.wikipedia.org/wiki/Florida_Coastal_Airlines^en|Florida Coastal Airlines|^^air-florida-coastal-airlines^1
 air-fly-excellent-v1^1^2007-01-01^2008-12-31^FXL^F3^0^Fly Excellent^^^^^^en|Fly Excellent|^ARN^air-fly-excellent^1
-air-flycongo-v1^1^^2013-31-12^ALX^EO^663^Flycongo^^^^^^en|Flycongo|^^air-flycongo^1
+air-flycongo-v1^1^^2013-12-31^ALX^EO^663^Flycongo^^^^^^en|Flycongo|^^air-flycongo^1
 air-flywell-airlines-v1^1^1995-01-01^2003-12-12^FEM^YZ^0^Zimbabwe Airlink^Flywell Airlines^^^P^http://en.wikipedia.org/wiki/Zimbabwe_Airlink^en|Zimbabwe Airlink|=en|Flywell Airlines|^^air-flywell-airlines^1
 air-fly-georgia-v1^1^2011-01-01^2013-12-31^FGE^9Y^671^Fly Georgia^^^^^http://en.wikipedia.org/wiki/Fly_Georgia^en|Fly Georgia|^^air-fly-georgia^1
 air-fly540-angola-v1^1^2011-01-01^2014-05-31^^FS^0^Fly540 Angola^^^^^http://en.wikipedia.org/wiki/Fly540_Angola^en|Fly540 Angola|^LAD^air-fly540-angola^1

--- a/opentraveldata/optd_airline_no_longer_valid.csv
+++ b/opentraveldata/optd_airline_no_longer_valid.csv
@@ -14,6 +14,7 @@ air-air-cargo-carriers-v1^1^1986-01-01^2003-12-31^SNC^2Q^0^Air Cargo Carriers^^^
 air-air-cargo-germany-v1^1^2009-01-01^2013-12-31^ACX^6U^0^Air Cargo Germany^^^^C^http://en.wikipedia.org/wiki/Air_Cargo_Germany^en|Air Cargo Germany|p=abbr|ACG|^HHN^air-air-cargo-germany^1
 air-air-caucasus-v1^1^2013-01-01^2014-12-31^CSG^UY^49^Air Caucasus^^^^^http://en.wikipedia.org/wiki/Air_Caucasus^en|Air Caucasus|^TBS^air-air-caucasus^1
 air-air-comet-v1^1^1996-01-01^2009-12-21^MPD^A7^0^Air Comet^Air Plus Comet^^^^http://en.wikipedia.org/wiki/Air_Comet^en|Air Comet|=en|Air Plus Comet|^^air-air-comet^1
+air-air-contact-v1^1^^^^KI^0^Air Contact^^^^^^^en|Air Contact|^^air-air-contact^1
 air-air-mediterranee-v1^1^1995-01-01^2016-02-15^BIE^ML^853^Air Mediterranee^^^^^http://en.wikipedia.org/wiki/Air_M%C3%A9diterran%C3%A9e^en|Air Mediterranee|^LDE=LYS=NTE^air-air-mediterranee^1
 air-air-mekong-v1^1^2009-01-01^2013-12-31^MKG^P8^819^Air Mekong^^^^^http://en.wikipedia.org/wiki/Air_Mekong^en|Air Mekong|^HAN=SGN^air-air-mekong^1
 air-air-ukraine-v1^1^1992-01-01^2002-12-31^UKR^6U^0^Air Ukraine^^^^^http://en.wikipedia.org/wiki/Air_Ukraine^en|Air Ukraine|^KBP^air-air-ukraine^1
@@ -238,6 +239,7 @@ air-pluna-v1^1^1936-09-01^2012-07-05^PUA^PU^286^PLUNA^^^^^http://en.wikipedia.or
 air-pmt-air-v1^1^2003-01-14^2008-12-31^PMT^U4^0^PMTair^^^^^http://en.wikipedia.org/wiki/PMTair^en|PMTair|s=en|Progress MulTi Air|^^air-pmt-air^1
 air-polet-airlines-v1^1^1988-01-01^2014-11-24^POT^YQ^342^Polet Airlines^^^^^http://en.wikipedia.org/wiki/Polet_Airlines^en|Polet Airlines|=ru|Авиакомпания Полёт|^^air-polet-airlines^1
 air-prima-air-v1^1^1996-01-01^1996-12-31^^QG^0^Prima Air^^^^^http://en.wikipedia.org/wiki/Prima_Air^en|Prima Air|^^air-prima-air^1
+air-primera-air-scandinavia-v1^1^2003-01-01^^PRI^PF^834^Primera Air Scandinavia^JetX^^^^http://en.wikipedia.org/wiki/Primera_Air^3847^en|Primera Air Scandinavia|=en|JetX|^^air-primera-air-scandinavia^1
 air-private-wings-v1^1^1991-01-01^2016-05-31^PWF^8W^0^Private Wings^^^^^http://en.wikipedia.org/wiki/Private_Wings^en|Private Wings|^SXF^air-private-wings^1
 air-rak-airways-v1^1^2007-01-01^2014-01-01^RKM^RT^0^RAK Airways^^^^^http://en.wikipedia.org/wiki/RAK_Airways^en|RAK Airways|^^air-rak-airways^1
 air-rheintalflug-v1^1^^2013-12-31^^WE^0^Rheintal flug^^^^^^en|Rheintal flug|^^air-rheintalflug^1

--- a/opentraveldata/optd_airlines.csv
+++ b/opentraveldata/optd_airlines.csv
@@ -227,18 +227,18 @@ air-alpha-air-transport-v1^^2014-01-01^^^7U^428^Alpha Air Transport^^^^^^^en|Alp
 air-alpi-eagles-v1^1^1979-01-01^2007-12-31^ELG^E8^0^Alpi Eagles^^^^^http://en.wikipedia.org/wiki/Alpi_Eagles^^en|Alpi Eagles|^^air-alpi-eagles^1
 air-alpine-air-v1^^^^^N6^0^Nomad Aviation^Aerocontinent^^^^^^en|Nomad Aviation|=en|Aerocontinent|^^air-alpine-air^1
 air-als-v1^^^^^K4^0^ALS^^^^^^^en|ALS|^^air-als^1
-air-amadeus-7n-v1^^2011-01-25^^^7N^^Amadeus 7N^Amadeus 7N^^^D^^4582^en|Amadeus 7N|=en|Amadeus 7N|^^air-amadeus-7n^1
+air-amadeus-7n-v1^1^2011-01-25^^^7N^^Amadeus 7N^Amadeus 7N^^^D^^4582^en|Amadeus 7N|=en|Amadeus 7N|^^air-amadeus-7n^1
 air-amadeus-8z-v1^1^^2014-06-01^^8Z^0^Amadeus 8Z^Amadeus 8Z^^^D^^^en|Amadeus 8Z|=en|Amadeus 8Z|^^air-amadeus-8z^1
-air-amadeus-eight-v1^^^^XYD^8X^794^Amadeus Eight^Amadeus Eight^^^D^^^en|Amadeus Eight|=en|Amadeus Eight|^^air-amadeus-eight^1
-air-amadeus-pdf-0e-v1^^^^XYS^0E^0^Amadeus PDF 0E^^^^D^^^en|Amadeus PDF 0E|^^air-amadeus-pdf-0e^1
+air-amadeus-eight-v1^1^^^XYD^8X^794^Amadeus Eight^Amadeus Eight^^^D^^^en|Amadeus Eight|=en|Amadeus Eight|^^air-amadeus-eight^1
+air-amadeus-pdf-0e-v1^1^^^XYS^0E^0^Amadeus PDF 0E^^^^D^^^en|Amadeus PDF 0E|^^air-amadeus-pdf-0e^1
 air-amadeus-pdf-2d-v1^1^2010-09-01^2010-09-30^^2D^0^Amadeus PDF 2D^^^^D^^^en|Amadeus PDF 2D|^^air-amadeus-pdf-2d^1
-air-amadeus-pdf-2y-v1^^^^^2Y^0^Amadeus PDF 2Y^^^^D^^^en|Amadeus PDF 2Y|^^air-amadeus-pdf-2y^1
-air-amadeus-pdf-7s-v1^^^^XYW^7S^792^Amadeus PDF 7S^Amadeus 7S^^^D^^3140^en|Amadeus PDF 7S|=en|Amadeus 7S|^^air-amadeus-pdf-7s^1
-air-amadeus-pdf-9s-v1^^^^XYX^9S^793^Amadeus PDF 9S^Amadeus 9S^^^D^^^en|Amadeus PDF 9S|=en|Amadeus 9S|^^air-amadeus-pdf-9s^1
-air-amadeus-pdf-9z-v1^^^^^9Z^0^Amadeus PDF 9Z^^^^D^^^en|Amadeus PDF 9Z|^^air-amadeus-pdf-9z^1
-air-amadeus-seven-v1^^^^XYC^7X^791^Amadeus Seven^Amadeus Seven^^^D^^^en|Amadeus Seven|=en|Amadeus Seven|^^air-amadeus-seven^1
-air-amadeus-six-v1^^^^XYB^6X^172^Amadeus Six^Amadeus Six^^^D^^^en|Amadeus Six|=en|Amadeus Six|^^air-amadeus-six^1
-air-amadeus-two-v1^^^^XYA^2X^799^Amadeus Two^Amadeus Two^^^D^^^en|Amadeus Two|=en|Amadeus Two|^^air-amadeus-two^1
+air-amadeus-pdf-2y-v1^1^^^^2Y^0^Amadeus PDF 2Y^^^^D^^^en|Amadeus PDF 2Y|^^air-amadeus-pdf-2y^1
+air-amadeus-pdf-7s-v1^1^^^XYW^7S^792^Amadeus PDF 7S^Amadeus 7S^^^D^^3140^en|Amadeus PDF 7S|=en|Amadeus 7S|^^air-amadeus-pdf-7s^1
+air-amadeus-pdf-9s-v1^1^^^XYX^9S^793^Amadeus PDF 9S^Amadeus 9S^^^D^^^en|Amadeus PDF 9S|=en|Amadeus 9S|^^air-amadeus-pdf-9s^1
+air-amadeus-pdf-9z-v1^1^^^^9Z^0^Amadeus PDF 9Z^^^^D^^^en|Amadeus PDF 9Z|^^air-amadeus-pdf-9z^1
+air-amadeus-seven-v1^1^^^XYC^7X^791^Amadeus Seven^Amadeus Seven^^^D^^^en|Amadeus Seven|=en|Amadeus Seven|^^air-amadeus-seven^1
+air-amadeus-six-v1^1^^^XYB^6X^172^Amadeus Six^Amadeus Six^^^D^^^en|Amadeus Six|=en|Amadeus Six|^^air-amadeus-six^1
+air-amadeus-two-v1^1^^^XYA^2X^799^Amadeus Two^Amadeus Two^^^D^^^en|Amadeus Two|=en|Amadeus Two|^^air-amadeus-two^1
 air-amakusa-airlines-v1^^2000-03-23^^AHX^MZ^0^Amakusa Airlines^^^^^http://en.wikipedia.org/wiki/Amakusa_Airlines^630^en|Amakusa Airlines|=ja|天草エアライン株式会社|=ko|아마쿠사 항공|=sign|AMAKUSA AIR|=zh|天草航空|^^air-amakusa-airlines^1
 air-amaszonas-del-paraguay-v1^^^^^ZP^0^Amaszonas Del Paraguay^^^^^^2192^en|Amaszonas Del Paraguay|^^air-amaszonas-del-paraguay^1
 air-amaszonas-v1^^1998-10-01^^^Z8^464^Línea Aérea Amaszonas^Amaszonas^^^^http://en.wikipedia.org/wiki/L%C3%ADnea_A%C3%A9rea_Amaszonas^22093^en|Línea Aérea Amaszonas|=en|Amaszonas|^^air-amaszonas^1

--- a/opentraveldata/optd_airlines.csv
+++ b/opentraveldata/optd_airlines.csv
@@ -580,7 +580,7 @@ air-flybaghdad-v1^^2015-06-15^^FBA^IF^0^FlyBaghdad^^^^^http://en.wikipedia.org/w
 air-flybe-v1^^1979-01-01^^BEE^BE^267^Flybe^Brit Europ^^^^http://en.wikipedia.org/wiki/Flybe^89393^en|Flybe|=en|Brit Europ|^^air-flybe^1
 air-fly-blue-crane-v1^^2015-09-01^^^7B^562^Fly Blue Crane^^^^^http://en.wikipedia.org/wiki/Fly_Blue_Crane^1475^en|Fly Blue Crane|^JNB^air-fly-blue-crane^1
 air-fly-caminter-v1^^2016-03-17^^^EF^448^Fly CamInter^^^^^^^en|Fly CamInter|=en|Equa2C|h^DLA^air-fly-caminter^1
-air-flycongo-v1^1^^2013-31-12^ALX^EO^663^Flycongo^^^^^^^en|Flycongo|^^air-flycongo^1
+air-flycongo-v1^1^^2013-12-31^ALX^EO^663^Flycongo^^^^^^^en|Flycongo|^^air-flycongo^1
 air-fly-corporate-v1^^2016-01-01^^^FC^441^Fly Corporate^^^^^^1025^en|Fly Corporate|p=en|Vee H Aviation Pty Ltd|^BNE^air-fly-corporate^1
 air-flydamas-v1^^^^^4J^0^Flydamas Airlines^^^^^^785^en|Flydamas Airlines|^^air-flydamas^1
 air-flydubai-v1^^2009-06-01^^FDB^FZ^141^flydubai^Dubai Aviation Corporation^^^^http://en.wikipedia.org/wiki/Flydubai^86723^en|flydubai|=en|Dubai Aviation Corporation|^^air-flydubai^1

--- a/opentraveldata/optd_airlines.csv
+++ b/opentraveldata/optd_airlines.csv
@@ -721,8 +721,8 @@ air-israir-airlines-v1^^^^ISR^6H^818^Israir Airlines^Israir Airlin^^^^^2794^en|I
 air-ital-v1^^^^^1Q^0^Joint Stock Company Ital^^^^^^^en|Joint Stock Company Ital|^^air-ital^1
 air-itek-air-v1^^^^IKA^GI^420^Itek Air^^^^^^^en|Itek Air|^^air-itek-air^1
 air-izhavia-v1^^^^IZA^I8^25^Izhavia^Aboriginalair^^^^^593^en|Izhavia|=en|Aboriginalair|^^air-izhavia^1
-air-jal-express-v1^^^^^JC^0^JAL Express^^OneWorld^Affiliate^^http://en.wikipedia.org/wiki/JAL_Express^6777^en|JAL Express|^^air-jal-express^1
-air-japan-air-commuter-v1^^^^JAC^3X^0^Japan Air Commuter^^^^^^^en|Japan Air Commuter|^KOJ^air-japan-air-commuter^1
+air-jal-express-v1^1^1998-07-01^2014-09-30^JC^0^JAL Express^^OneWorld^Affiliate^^http://en.wikipedia.org/wiki/JAL_Express^6777^en|JAL Express|^^air-jal-express^1
+air-japan-air-commuter-v1^^^^JAC^JC^0^Japan Air Commuter^^^^^^^en|Japan Air Commuter|^KOJ^air-japan-air-commuter^1
 air-japan-airlines-v1^^1951-10-25^^JAL^JL^131^Japan Airlines^JAL^OneWorld^Member^^http://en.wikipedia.org/wiki/Japan_Airlines^281503^en|Japan Airlines|=en|JAL|^^air-japan-airlines^1
 air-japan-transocean-air-v1^^^^JTA^NU^353^Japan Transocean Air^Japan Transoc^OneWorld^Affiliate^^^23106^en|Japan Transocean Air|=en|Japan Transoc|^^air-japan-transocean-air^1
 air-jatayu-gelang-sejahtera-v1^^2014-01-25^^JTY^JZ^0^Jatayu Airlines^Jatayu Gelang Sejahtera^^^^http://en.wikipedia.org/wiki/Jatayu_Airlines^^en|Jatayu Airlines|=en|Jatayu Gelang Sejahtera|^^air-jatayu-gelang-sejahtera^1

--- a/opentraveldata/optd_airlines.csv
+++ b/opentraveldata/optd_airlines.csv
@@ -721,7 +721,7 @@ air-israir-airlines-v1^^^^ISR^6H^818^Israir Airlines^Israir Airlin^^^^^2794^en|I
 air-ital-v1^^^^^1Q^0^Joint Stock Company Ital^^^^^^^en|Joint Stock Company Ital|^^air-ital^1
 air-itek-air-v1^^^^IKA^GI^420^Itek Air^^^^^^^en|Itek Air|^^air-itek-air^1
 air-izhavia-v1^^^^IZA^I8^25^Izhavia^Aboriginalair^^^^^593^en|Izhavia|=en|Aboriginalair|^^air-izhavia^1
-air-jal-express-v1^1^1998-07-01^2014-09-30^JC^0^JAL Express^^OneWorld^Affiliate^^http://en.wikipedia.org/wiki/JAL_Express^6777^en|JAL Express|^^air-jal-express^1
+air-jal-express-v1^1^1998-07-01^2014-09-30^^JC^0^JAL Express^^OneWorld^Affiliate^^http://en.wikipedia.org/wiki/JAL_Express^6777^en|JAL Express|^^air-jal-express^1
 air-japan-air-commuter-v1^^^^JAC^JC^0^Japan Air Commuter^^^^^^^en|Japan Air Commuter|^KOJ^air-japan-air-commuter^1
 air-japan-airlines-v1^^1951-10-25^^JAL^JL^131^Japan Airlines^JAL^OneWorld^Member^^http://en.wikipedia.org/wiki/Japan_Airlines^281503^en|Japan Airlines|=en|JAL|^^air-japan-airlines^1
 air-japan-transocean-air-v1^^^^JTA^NU^353^Japan Transocean Air^Japan Transoc^OneWorld^Affiliate^^^23106^en|Japan Transocean Air|=en|Japan Transoc|^^air-japan-transocean-air^1

--- a/opentraveldata/optd_airlines.csv
+++ b/opentraveldata/optd_airlines.csv
@@ -95,7 +95,7 @@ air-air-china-v1^^1988-01-01^^CCA^CA^999^Air China^^Star Alliance^Member^^http:/
 air-air-city-v1^^^^ECE^4F^0^Air City^^^^^^^en|Air City|^^air-air-city^1
 air-air-comet-v1^1^1996-01-01^2009-12-21^MPD^A7^0^Air Comet^Air Plus Comet^^^^http://en.wikipedia.org/wiki/Air_Comet^^en|Air Comet|=en|Air Plus Comet|^^air-air-comet^1
 air-aircompany-armenia-v1^^2016-05-01^^NGT^RM^437^Aircompany Armenia^^^^^^409^en|Aircompany Armenia|^EVN^air-aircompany-armenia^1
-air-air-contact-v1^^^^^KI^0^Air Contact^^^^^^^en|Air Contact|^^air-air-contact^1
+air-air-contact-v1^1^^^^KI^0^Air Contact^^^^^^^en|Air Contact|^^air-air-contact^1
 air-air-corsica-v1^^2010-01-01^^CCM^XK^146^Air Corsica^^^^^http://en.wikipedia.org/wiki/Air_Corsica^18656^en|Air Corsica|^AJA^air-air-corsica^1
 air-air-cote-d-ivoire-v1^^^^^HF^483^Air Cote D Ivoire^Aircoteivoire^^^^^15210^en|Air Cote D Ivoire|=en|Aircoteivoire|^^air-air-cote-d-ivoire^1
 air-air-creebec-v1^^^^CRQ^YN^219^Air Creebec^Air Creebec^^^^^10504^en|Air Creebec|=en|Air Creebec|^^air-air-creebec^1
@@ -375,7 +375,7 @@ air-cargolux-italia-v1^1^^2013-12-31^^C8^0^Cargolux Italia^^^^C^^^en|Cargolux It
 air-cargolux-v1^^1970-03-04^^CLX^CV^172^Cargolux^^^^C^http://en.wikipedia.org/wiki/Cargolux^^en|Cargolux|^^air-cargolux^1
 air-carib-aviation-v1^^^^^3Q^0^Carib Aviation Limited^Yunnan Air^^^^^^en|Carib Aviation Limited|=en|Yunnan Air|^^air-carib-aviation^1
 air-caribbean-airlines-v1^^2007-01-01^^BWA^BW^106^Caribbean Airlines^^^^^http://en.wikipedia.org/wiki/Caribbean_Airlines^33778^en|Caribbean Airlines|^^air-caribbean-airlines^1
-air-caribbean-sun-airlines-v1^^2002-01-01^^WAL^K8^0^World Atlantic Airlines^Caribbean Sun Airlines^^^^http://en.wikipedia.org/wiki/World_Atlantic_Airlines^1493^en|World Atlantic Airlines|=en|Caribbean Sun Airlines|^^air-caribbean-sun-airlines^1
+air-caribbean-sun-airlines-v1^^2002-01-01^^WAL^^0^World Atlantic Airlines^Caribbean Sun Airlines^^^^http://en.wikipedia.org/wiki/World_Atlantic_Airlines^1493^en|World Atlantic Airlines|=en|Caribbean Sun Airlines|^^air-caribbean-sun-airlines^1
 air-caribbean-winds-airlines-v1^^^^WND^W8^0^Caribbean Winds Airlines^La Costena^^^^^^en|Caribbean Winds Airlines|=en|La Costena|^^air-caribbean-winds-airlines^1
 air-carpatair-v1^^1999-02-01^^KRP^V3^21^Carpatair^^^^^http://en.wikipedia.org/wiki/Carpatair^116^en|Carpatair|=en|Veg Air|h=sign|CARPATAIR|^^air-carpatair^1
 air-caspian-airlines-v1^1^1993-01-01^2015-12-31^CPN^IV^864^Caspian Airlines^^^^^http://en.wikipedia.org/wiki/Caspian_Airlines^^en|Caspian Airlines|^^air-caspian-airlines^1
@@ -385,7 +385,7 @@ air-cayman-airways-v1^^^^CAY^KX^378^Cayman Airways^^^^^^10499^en|Cayman Airways|
 air-cebu-air-v1^^1996-03-08^^CEB^5J^203^Cebu Pacific^^^^^http://en.wikipedia.org/wiki/Cebu_Pacific^110488^en|Cebu Pacific|=en|Cebu Air|^CEB^air-cebu-air^1
 air-ceiba-v1^^^^^C2^304^Ceiba Intercontinental^Ceiba^^^^^5487^en|Ceiba Intercontinental|=en|Ceiba|^^air-ceiba^1
 air-cemair-v1^^2005-01-01^^^5Z^225^CemAir^^^^^http://en.wikipedia.org/wiki/CemAir^5515^en|CemAir|^^air-cemair^1
-air-central-air-transport-services-v1^^^^^ZO^0^Central Air Transport Services^^^^^^^en|Central Air Transport Services|^^air-central-air-transport-services^1
+air-central-air-transport-services-v1^^^^^^0^Central Air Transport Services^^^^^^^en|Central Air Transport Services|^^air-central-air-transport-services^1
 air-central-mountain-air-v1^^^^GLR^9M^634^Central Mountain Air^^^^^^6779^en|Central Mountain Air|^^air-central-mountain-air^1
 air-centralwings-v1^^^^CLW^C0^0^Centralwings^^^^^^^en|Centralwings|^^air-centralwings^1
 air-centre-avia-v1^1^2000-01-01^2010-12-31^CVC^J7^0^Centre-Avia^^^^^http://en.wikipedia.org/wiki/Centre-Avia^^en|Centre-Avia|=ru|Авиакомпания "ЦЕНТР-АВИА"|^BKA^air-centre-avia^1
@@ -671,7 +671,7 @@ air-himalaya-airlines-v1^^2015-04-01^^HIM^H9^769^Himalaya Airlines^^^^^http://en
 air-hokkaido-air-system-v1^^1997-09-30^^NTH^^^Hokkaido Air System^^^^^http://en.wikipedia.org/wiki/Hokkaido_Air_System^^en|Hokkaido Air System|=jp|株式会社北海道エアシステム|^^air-hokkaido-air-system^1
 air-hokkaido-v1^^1998-05-12^^ADO^HD^0^Air Do^Hokkaido International Airlines^^^^http://en.wikipedia.org/wiki/Air_Do^50974^en|Air Do|=en|Hokkaido International Airlines|^^air-hokkaido^1
 air-holidays-czech-airlines-v1^^^^^HC^0^Holidays Czech Airlines^Aero Tropics^^^^^^en|Holidays Czech Airlines|=en|Aero Tropics|^^air-holidays-czech-airlines^1
-air-homer-air-v1^^^^^HB^^Homer Air^^^^^^386^en|Homer Air|^^air-homer-air^1
+air-homer-air-v1^^^^^^^Homer Air^^^^^^386^en|Homer Air|^^air-homer-air^1
 air-hong-kong-airlines-v1^^^^CRK^HX^851^Hong Kong Airlines^^^^^^33530^en|Hong Kong Airlines|^^air-hong-kong-airlines^1
 air-hong-kong-express-airways-v1^^^^HKE^UO^128^Hong Kong Express Airways^^^^^^17710^en|Hong Kong Express Airways|^^air-hong-kong-express-airways^1
 air-hop-airlinair-v1^^^^RLA^AN^0^HOP Airlinair^^^^^http://en.wikipedia.org/wiki/Airlinair^^en|HOP Airlinair|^^air-hop-airlinair^1
@@ -688,7 +688,7 @@ air-iberworld-airlines-v1^^1998-04-11^^IWD^IP^560^Iberworld Airlines^Atyrauauejo
 air-ibex-airlines-v1^^2000-08-07^^IBX^FW^0^Ibex Airlines^^^^^http://en.wikipedia.org/wiki/Ibex_Airlines^27486^en|Ibex Airlines|^^air-ibex-airlines^1
 air-icelandair-v1^^1937-01-01^^ICE^FI^108^Icelandair^^^^^http://en.wikipedia.org/wiki/Icelandair^25117^en|Icelandair|^^air-icelandair^1
 air-ihy-izmir-havayollari-v1^^^^IZM^4I^597^Ihy Izmir Havayollari^^^^^^^en|Ihy Izmir Havayollari|^^air-ihy-izmir-havayollari^1
-air-ikar-v1^^1993-06-15^^KAR^IK^0^Ikar^^^^^http://en.wikipedia.org/wiki/Ikar_(airline)^42^en|Ikar|^^air-ikar^1
+air-ikar-v1^^1993-06-15^^KAR^IK^0^Pegas Fly^Ikar^^^^http://en.wikipedia.org/wiki/Ikar_(airline)^42^en|Pegas Fly|=en|Ikar|^^air-ikar^1
 air-iliamna-air-v1^^^^IAR^V8^0^Iliamna Air^Contact Air^^^^^785^en|Iliamna Air|=en|Contact Air|^^air-iliamna-air^1
 air-indigo-v1^^2006-08-04^^IGO^6E^0^IndiGo^^^^^http://en.wikipedia.org/wiki/IndiGo^332488^en|IndiGo|^^air-indigo^1
 air-indonesia-air-transport-v1^1^1968-01-01^2015-12-31^IDA^I7^0^Indonesia Air Transport^^^^^http://en.wikipedia.org/wiki/Indonesia_Air_Transport^^abbr|IAT|=en|Indonesia Air Transport|=sign|INTRA|^^air-indonesia-air-transport^1
@@ -763,7 +763,7 @@ air-kartika-airlines-v1^1^2001-05-15^2010-12-31^KAE^3Y^0^Kartika Airlines^^^^^ht
 air-katekavia-v1^^1995-05-01^^KTK^ZF^0^Azur Air^^^^^http://en.wikipedia.org/wiki/Azur_Air^^en|Azur Air|=en|Katekavia|h=ru|АЗУР эйр|=ru|Катэкавиа|h^^air-katekavia^1
 air-katmai-air-v1^1^^2015-12-31^^KT^0^Katmai Air^^^^^http://www.katmailand.com/air-services^^en|Katmai Air|^BKF^air-katmai-air^1
 air-kato-airline-v1^1^1996-01-01^2008-09-01^KAT^6S^0^Kato Airlines^^^^^http://en.wikipedia.org/wiki/Kato_Airline^^en|Kato Airlines|=en|Kato Air|ps^BOO=EVE=TRD^air-kato-airline^1
-air-kaya-airlines-v1^^1991-01-01^^KYY^IK^0^Kaya Airlines^Imair Air^^^^http://en.wikipedia.org/wiki/Kaya_Airlines^42^en|Kaya Airlines|=en|Imair Air|^^air-kaya-airlines^1
+air-kaya-airlines-v1^^1991-01-01^^KYY^^0^Kaya Airlines^Imair Air^^^^http://en.wikipedia.org/wiki/Kaya_Airlines^42^en|Kaya Airlines|=en|Imair Air|^^air-kaya-airlines^1
 air-kd-v1^1^1990-01-01^2013-09-30^KDC^XC^0^KD Air^^^^^http://en.wikipedia.org/wiki/KD_Air^^en|KD Air|=sign|KAYDEE|^YVR^air-kd^1
 air-kd-v2^^2013-10-01^^KDC^^0^KD Air^^^^^http://en.wikipedia.org/wiki/KD_Air^^en|KD Air|=sign|KAYDEE|^YVR^air-kd^2
 air-kenmore-air-v1^^^^KEN^M5^763^Kenmore Air^^^^^^814^en|Kenmore Air|^^air-kenmore-air^1
@@ -893,14 +893,14 @@ air-ms-royal-airlines-v1^^^^^R0^333^MS Royal Airlines^^^^^^^en|MS Royal Airlines
 air-myanmar-airways-v1^^1946-01-01^^MMA^8M^599^Myanmar Airways International^^^^^http://en.wikipedia.org/wiki/Myanmar_Airways_International^3235^en|Myanmar Airways International|^RGN^air-myanmar-airways^1
 air-myanmar-utd-v1^^1948-09-15^^UBA^UB^665^Myanmar National Airlines^UTD Myanmar^^^^http://en.wikipedia.org/wiki/Myanmar_National_Airlines^8925^en|Myanmar National Airlines|=en|UTD Myanmar|^^air-myanmar-utd^1
 air-nacil-indian-airline-v1^^^^^IC^58^Nacil Indian Airline^^^^^^^en|Nacil Indian Airline|^^air-nacil-indian-airline^1
-air-nakina-air-service-v1^^1973-01-01^^^T2^0^Nakina Air Service^^^^^http://en.wikipedia.org/wiki/Nakina_Air_Service^^en|Nakina Air Service|=sign|NAKINA|^YQN^air-nakina-air-service^1
+air-nakina-air-service-v1^^1973-01-01^^^^0^Nakina Air Service^^^^^http://en.wikipedia.org/wiki/Nakina_Air_Service^^en|Nakina Air Service|=sign|NAKINA|^YQN^air-nakina-air-service^1
 air-nam-air-v1^^2013-12-11^^NIH^IN^274^NAM Air^^^^^http://en.wikipedia.org/wiki/NAM_Air^31319^en|NAM Air|^^air-nam-air^1
 air-nasair-uair-v1^^^^^UE^770^Nasair^^^^^^^en|Nasair|^^air-nasair-uair^1
 air-nasair-v1^^2007-02-01^^KNE^XY^593^Flynas^Nas Air^^^^http://en.wikipedia.org/wiki/Flynas^44415^en|Flynas|=en|Nas Air|^^air-nasair^1
 air-national-airlines-v1^^^^MUA^N8^416^National Airlines^^^^^^9^en|National Airlines|^^air-national-airlines^1
 air-national-airways-cameroon-v1^1^1999-11-01^2000-03-01^^9O^357^National Airways Cameroon^Aircameroon^^^^http://en.wikipedia.org/wiki/National_Airways_Cameroon^^en|National Airways Cameroon|=en|Aircameroon|^^air-national-airways-cameroon^1
-air-national-airways-ethiopia-v1^^2007-11-01^^^7N^789^National Airways Ethiopia^^^^^http://en.wikipedia.org/wiki/National_Airways_Ethiopia^4582^en|National Airways Ethiopia|^^air-national-airways-ethiopia^1
-air-national-airways-v1^^2015-05-01^^^9Y^0^National Airways^^^^^^4656^en|National Airways|^^air-national-airways^1
+air-national-airways-ethiopia-v1^^2007-11-01^^^^789^National Airways Ethiopia^^^^^http://en.wikipedia.org/wiki/National_Airways_Ethiopia^4582^en|National Airways Ethiopia|^^air-national-airways-ethiopia^1
+air-national-airways-v1^^2015-05-01^^^^0^National Airways^^^^^^4656^en|National Airways|^^air-national-airways^1
 air-national-jet-systems-v1^1^1990-07-01^2009-02-28^NJS^NC^0^National Jet Systems^^OneWorld^Affiliate^^http://en.wikipedia.org/wiki/Cobham_Aviation_Services_Australia^^en|Cobham Aviation Services Australia|p=en|National Jet Systems|h^^air-national-jet-systems^1
 air-national-jet-systems-v2^^2009-03-01^^JTE^NC^0^Cobham Aviation Services Australia^^OneWorld^Affiliate^^http://en.wikipedia.org/wiki/Cobham_Aviation_Services_Australia^^en|Cobham Aviation Services Australia|p=en|National Jet Systems|h^^air-national-jet-systems^2
 air-nature-air-v1^^^^^5C^0^Nature Air^^^^^^8603^en|Nature Air|^^air-nature-air^1
@@ -1006,8 +1006,8 @@ air-premier-trans-aire-v1^^^^^3X^435^Premier Trans Aire^^^^C^http://de.wikipedia
 air-premium-jet-v1^^^^^0J^254^Premium Jet AG^^^^^^^en|Premium Jet AG|^^air-premium-jet^1
 air-prima-air-v1^1^1996-01-01^1996-12-31^^QG^0^Prima Air^^^^^http://en.wikipedia.org/wiki/Prima_Air^^en|Prima Air|^^air-prima-air^1
 air-primera-air-nordic-v1^^2015-04-01^^PRW^6F^0^Primera Air Nordic^^^^^http://en.wikipedia.org/wiki/Primera_Air^3623^en|Primera Air Nordic|^^air-primera-air-nordic^1
-air-primera-air-scandinavia-v1^^2003-01-01^^PRI^PF^834^Primera Air Scandinavia^JetX^^^^http://en.wikipedia.org/wiki/Primera_Air^3847^en|Primera Air Scandinavia|=en|JetX|^^air-primera-air-scandinavia^1
-air-primera-air-v1^^2003-01-01^^PRI^PF^0^Primera Air^^^^^http://en.wikipedia.org/wiki/Primera_Air^3847^en|Primera Air|^^air-primera-air^1
+air-primera-air-scandinavia-v1^1^2003-01-01^^PRI^PF^834^Primera Air Scandinavia^JetX^^^^http://en.wikipedia.org/wiki/Primera_Air^3847^en|Primera Air Scandinavia|=en|JetX|^^air-primera-air-scandinavia^1
+air-primera-air-v1^^2003-01-01^^PRI^PF^0^Primera Air^JetX^^^^http://en.wikipedia.org/wiki/Primera_Air^3847^en|Primera Air|=en|JetX|^^air-primera-air^1
 air-private-wings-v1^1^1991-01-01^2016-05-31^PWF^8W^0^Private Wings^^^^^http://en.wikipedia.org/wiki/Private_Wings^^en|Private Wings|^SXF^air-private-wings^1
 air-proflight-commuter-v1^^^^PFZ^P0^659^Proflight Commuter^Proflight^^^^^6207^en|Proflight Commuter|=en|Proflight|^^air-proflight-commuter^1
 air-provincial-airlines-v1^^^^SPR^PB^967^Provincial Airlines^Provincial^^^^^17544^en|Provincial Airlines|=en|Provincial|^^air-provincial-airlines^1
@@ -1045,7 +1045,7 @@ air-royal-air-force-v1^^^^RFR^RR^0^Royal Air Force^RAF NO^^^^^^en|Royal Air Forc
 air-royal-air-maroc-v1^^1957-01-01^^RAM^AT^147^Royal Air Maroc^^^^^http://en.wikipedia.org/wiki/Royal_Air_Maroc^75543^abbr|RAM|=en|RAM|ps=en|Royal Air Maroc|^^air-royal-air-maroc^1
 air-royal-brunei-v1^^^^RBA^BI^672^Royal Brunei^Royalbrunei^^^^^11344^en|Royal Brunei|=en|Royalbrunei|^^air-royal-brunei^1
 air-royal-falcon-v1^^^^RFJ^RL^372^Royal Falcon^^^^^^^en|Royal Falcon|^^air-royal-falcon^1
-air-royal-flight-v1^^2014-01-01^^ABG^4R^^Royal Flight^^^^^http://en.wikipedia.org/wiki/Royal_Flight_%28airline%29^^en|Royal Flight|^^air-royal-flight^1
+air-royal-flight-v1^^2014-01-01^^ABG^RL^^Royal Flight^^^^^http://en.wikipedia.org/wiki/Royal_Flight_%28airline%29^^en|Royal Flight|^^air-royal-flight^1
 air-royal-jordanian-v1^^1963-12-09^^RJA^RJ^512^Royal Jordanian^Ryljordania^OneWorld^Member^^http://en.wikipedia.org/wiki/Royal_Jordanian^35346^en|Royal Jordanian|=en|Ryljordania|^^air-royal-jordanian^1
 air-royal-wings-v1^^1996-01-01^^RYW^RY^561^Royal Wings^^^^^http://en.wikipedia.org/wiki/Royal_Wings^3289^ar|الأجنحة الملكية|=en|Royal Wings|^^air-royal-wings^1
 air-ruili-airlines-v1^^^^^DR^0^Ruili Airlines^Air Link^^^^^23056^en|Ruili Airlines|=en|Air Link|^^air-ruili-airlines^1
@@ -1365,7 +1365,7 @@ air-ygnus-air-v1^^^^RGN^Y2^571^Ygnus Air^^^^^^^en|Ygnus Air|^^air-ygnus-air^1
 air-yunnan-hongtu-airlines-v1^^2016-01-01^^HTU^A6^389^Yunnan Hongtu Airline^^^^^http://en.wikipedia.org/wiki/Yunnan_Hongtu_Airlines^^en|Yunnan Hongtu Airlines|=wuu|云南红土航空股份有限公司|=yue|雲南紅土航空股份有限公司|=pny|Yúnnán Hóngtǔ Hángkōng Gǔfèn Yǒuxiàn Gōngsī|^KMG^air-yunnan-hongtu-airlines^1
 air-yunnan-yingan-airline-v1^^^^^YI^852^Yunnan Yingan Airline^^^^^^^en|Yunnan Yingan Airline|^^air-yunnan-yingan-airline^1
 air-yute-air-alaska-v1^^1950-01-01^^TUD^4Y^0^Flight Alaska^Yute Air Alaska^^^PT^http://en.wikipedia.org/wiki/Flight_Alaska^35928^en|Flight Alaska|=en|Yute Air Alaska|^^air-yute-air-alaska^1
-air-zagros-airlines-v1^^2005-01-01^^IZG^ZO^0^Zagros Airlines^^^^^http://en.wikipedia.org/wiki/Zagros_Airlines^^en|Zagros Airlines|^^air-zagros-airlines^1
+air-zagros-airlines-v1^^2005-01-01^^IZG^Z4^0^Zagros Airlines^^^^^http://en.wikipedia.org/wiki/Zagros_Airlines^^en|Zagros Airlines|^^air-zagros-airlines^1
 air-zagros-air-v1^^2005-10-01^^GZQ^Z4^541^Zagrosjet^^^^^http://en.wikipedia.org/wiki/Zagrosjet^1726^en|Zagrosjet|=en|Zagros Air|h^EBL^air-zagros-air^1
 air-zambezi-airlines-v1^^^^ZMA^ZJ^707^Zambezi Airlines^^^^^^^en|Zambezi Airlines|^^air-zambezi-airlines^1
 air-zambian-airways-v1^1^1948-01-01^2009-12-31^MBN^Q3^0^Zambian Airways^^^^^http://en.wikipedia.org/wiki/Zambian_Airways^^en|Zambian Airways|^^air-zambian-airways^1


### PR DESCRIPTION
1. Correct the date format of 'Flycongo'.
2. Deprecated JAL Express and correct the IATA code of Japan Air Commuter.
3. Deprecated inexistent airlines.
4. Deprecated Air Contact.
5. Remove IATA code of World Atlantic Airlines, Central Air Transport Services, Home Air, Kaya Airlines, Nakina Air Service, National Airways Ethiopia, National Airways.
6. Correct IATA code of Royal Flight, Zagros Airlines.
7. Revise current name of Ikar to Pegas Fly.