### PR TITLE
China Southern (CZ) leaving Sky Team

### DIFF
--- a/opentraveldata/optd_airline_alliance_membership.csv
+++ b/opentraveldata/optd_airline_alliance_membership.csv
@@ -54,7 +54,7 @@ Skyteam^Member^CI^China Airlines^2011-09-28^^
 Skyteam^Affiliate^AE^Mandarin Airlines^2011-09-28^^
 Skyteam^Member^MU^China Eastern Airlines^2011-06-21^^
 Skyteam^Affiliate^FM^Shanghai Airlines^2011-06-21^^
-Skyteam^Member^CZ^China Southern Airlines^2007-11-15^^
+Skyteam^Member^CZ^China Southern Airlines^2007-11-15^2018-12-31^
 Skyteam^Member^CO^Continental Airlines^2004-09-13^2009-10-24^1
 Skyteam^Member^OK^Czech Airlines^2001-03-25^^
 Skyteam^Member^DL^Delta Air Lines^2000-06-22^^


### PR DESCRIPTION
China Southern decided to leave Sky Team as of 1 Jan 2019.
https://www.skyteam.com/en/about/press-releases/press-releases-2018/update-skyteam-and-China-Southern/