### PR TITLE
[Airlines] Added DN/NAA/Norwegian Air Argentina, deprecated DN/SGG/Senegal Airlines

### DIFF
--- a/opentraveldata/optd_airline_best_known_so_far.csv
+++ b/opentraveldata/optd_airline_best_known_so_far.csv
@@ -709,6 +709,7 @@ air-north-flying-v1^^2014-01-01^^NFA^^0^North Flying^^^^^https://en.wikipedia.or
 air-northwest-airlines-v1^^^^^NW^0^Northwest Airlines^Nwest Airlines^^^^^en|Northwest Airlines|=en|Nwest Airlines|^^air-northwest-airlines^1^
 air-northwestern-air-lease-v1^^^^PLR^J3^0^Northwestern Air Lease^Nw Air Lease^^^^^en|Northwestern Air Lease|=en|Nw Air Lease|^^air-northwestern-air-lease^1^
 air-north-wright-air-v1^^^^^HW^0^North Wright Air^North Wright^^^^^en|North Wright Air|=en|North Wright|^^air-north-wright-air^1^
+air-norwegian-air-argentina-v1^^2017-01-25^^NAA^DN^0^Norwegian Air Argentina^^^^^https://en.wikipedia.org/wiki/Norwegian_Air_Argentina^en|Norwegian Air Argentina|^AEP^air-norwegian-air-argentina^1^
 air-norwegian-air-international-v1^^2012-01-01^^IBK^D8^0^Norwegian Air International^^^^^https://en.wikipedia.org/wiki/Norwegian_Air_International^en|Norwegian Air International|^OSL^air-norwegian-air-international^1^
 air-norwegian-air-shuttle-v1^^1993-01-01^^NAX^DY^328^Norwegian Air Shuttle (NAS)^^^^^https://en.wikipedia.org/wiki/Norwegian_Air_Shuttle^en|Norwegian Air Shuttle (NAS)|^^air-norwegian-air-shuttle^1^
 air-norwegian-air-uk-v1^^2015-01-01^^NRS^DI^762^Norwegian Air UK^^^^^^en|Norwegian Air UK|^DUB^air-norwegian-air-uk^1^
@@ -833,7 +834,6 @@ air-scott-air-v1^^^^^I4^0^Scott Air^^^^^^en|Scott Air|^^air-scott-air^1^
 air-seaborne-airlines-v1^^1992-01-01^^SBS^BB^376^Seaborne Airlines^^^^^https://en.wikipedia.org/wiki/Seaborne_Airlines^en|Seaborne Airlines|^^air-seaborne-airlines^1^
 air-seair-v1^^^^^XO^0^Seair^Xinjiang^^^^^en|Seair|=en|Xinjiang|^^air-seair^1^
 air-seaport-airlines-v1^^2008-06-05^^SQH^K5^609^SeaPort^^^^P^https://en.wikipedia.org/wiki/SeaPort_Airlines^en|SeaPort|ps=en|Wings of Alaska|h^^air-seaport-airlines^1^
-air-senegal-airlines-v1^^^^^DN^440^Senegal Airlines^^^^^^en|Senegal Airlines|^^air-senegal-airlines^1^
 air-serene-air-v1^^2017-01-29^^SEP^ER^0^SereneAir^^^^^https://en.wikipedia.org/wiki/SereneAir^en|SereneAir|=ur|سیرین ایئر|^ISB^air-serene-air^1^
 air-servant-air-v1^^^^^8D^0^Servant Air^^^^^^en|Servant Air|^^air-servant-air^1^
 air-servicios-aereos-andes-v1^^2014-01-01^^AND^^323^Servicios Aéreos de los Andes^Servicios Aereos de los Andes^^^^^en|Servicios Aéreos de los Andes|=en|Andes Air|s^^air-servicios-aereos-andes^1^

--- a/opentraveldata/optd_airline_no_longer_valid.csv
+++ b/opentraveldata/optd_airline_no_longer_valid.csv
@@ -289,6 +289,7 @@ air-sarit-airlines-v1^1^1997-01-01^2004-06-30^BDR^J4^0^Badr Airlines^^^^^https:/
 air-sas-braathens-v1^1^1946-01-01^2007-12-31^CNO^BU^117^Scandinavian Airlines^^Star Alliance^Member^^https://en.wikipedia.org/wiki/SAS_Braathens^en|SAS Braathens|^^air-sas-braathens^1^
 air-scotairways-v1^1^^2013-03-31^SAY^CB^969^ScotAirways^^^^^https://en.wikipedia.org/wiki/Suckling_Airways^en|ScotAirways|=en|ScotAirways|^^air-scotairways^1^
 air-semeyavia-v1^1^1997-01-01^2013-12-31^SMK^E8^0^SA Regional Airlines^^^^^https://en.wikipedia.org/wiki/Semeyavia^en|SA Regional Airlines|p=en|Semeyavia|h=ru|Семейавиа|h^ALA^air-semeyavia^1^
+air-senegal-airlines-v1^^2011-01-25^2016-04-01^SGG^DN^440^Senegal Airlines^^^^^https://en.wikipedia.org/wiki/Senegal_Airlines^en|Senegal Airlines|^^air-senegal-airlines^1^
 air-shanxi-airlines-v1^1^2001-07-06^2009-12-31^CXI^8C^0^Shanxi Airlines^^^^^https://en.wikipedia.org/wiki/Shanxi_Airlines^en|Shanxi Airlines|=sign|SHANXI|^^air-shanxi-airlines^1^
 air-siam-air-transport-v1^1^2014-01-01^2016-09-30^SQM^O8^874^Siam Air^^^^^https://en.wikipedia.org/wiki/Siam_Air^en|Siam Air|^DMK^air-siam-air-transport^1^
 air-siam-ga-v1^1^2002-01-01^2014-12-31^SGN^5E^0^SGA Airlines^^^^^https://en.wikipedia.org/wiki/SGA_Airlines^en|SGA Airlines|ps=en|Siam GA|s=en|Siam General Aviation|=th|บริษัท สยาม เจนเนอรัล เอวิเอชั่น จำกัด|^DMK^air-siam-ga^1^

--- a/opentraveldata/optd_airlines.csv
+++ b/opentraveldata/optd_airlines.csv
@@ -974,6 +974,7 @@ air-north-flying-v1^^2014-01-01^^NFA^^0^North Flying^^^^^https://en.wikipedia.or
 air-north-wright-air-v1^^^^^HW^0^North Wright Air^North Wright^^^^^531^en|North Wright Air|=en|North Wright|^^air-north-wright-air^1^^
 air-northwest-airlines-v1^^^^^NW^0^Northwest Airlines^Nwest Airlines^^^^^^en|Northwest Airlines|=en|Nwest Airlines|^^air-northwest-airlines^1^^
 air-northwestern-air-lease-v1^^^^PLR^J3^0^Northwestern Air Lease^Nw Air Lease^^^^^374^en|Northwestern Air Lease|=en|Nw Air Lease|^^air-northwestern-air-lease^1^^
+air-norwegian-air-argentina-v1^^2017-01-25^^NAA^DN^0^Norwegian Air Argentina^^^^^https://en.wikipedia.org/wiki/Norwegian_Air_Argentina^^en|Norwegian Air Argentina|^AEP^air-norwegian-air-argentina^1^^
 air-norwegian-air-international-v1^^2012-01-01^^IBK^D8^0^Norwegian Air International^^^^^https://en.wikipedia.org/wiki/Norwegian_Air_International^6184^en|Norwegian Air International|^OSL^air-norwegian-air-international^1^^
 air-norwegian-air-shuttle-v1^^1993-01-01^^NAX^DY^328^Norwegian Air Shuttle (NAS)^^^^^https://en.wikipedia.org/wiki/Norwegian_Air_Shuttle^12314^en|Norwegian Air Shuttle (NAS)|^^air-norwegian-air-shuttle^1^^
 air-norwegian-air-uk-v1^^2015-01-01^^NRS^DI^762^Norwegian Air UK^^^^^^^en|Norwegian Air UK|^DUB^air-norwegian-air-uk^1^^
@@ -1123,7 +1124,7 @@ air-seaborne-airlines-v1^^1992-01-01^^SBS^BB^376^Seaborne Airlines^^^^^https://e
 air-seair-v1^^^^^XO^0^Seair^Xinjiang^^^^^10^en|Seair|=en|Xinjiang|^^air-seair^1^^
 air-seaport-airlines-v1^^2008-06-05^^SQH^K5^609^SeaPort^^^^P^https://en.wikipedia.org/wiki/SeaPort_Airlines^571^en|SeaPort|ps=en|Wings of Alaska|h^^air-seaport-airlines^1^^
 air-semeyavia-v1^1^1997-01-01^2013-12-31^SMK^E8^0^SA Regional Airlines^^^^^https://en.wikipedia.org/wiki/Semeyavia^^en|SA Regional Airlines|p=en|Semeyavia|h=ru|Семейавиа|h^ALA^air-semeyavia^1^^
-air-senegal-airlines-v1^^^^^DN^440^Senegal Airlines^^^^^^73^en|Senegal Airlines|^^air-senegal-airlines^1^^
+air-senegal-airlines-v1^^2011-01-25^2016-04-01^SGG^DN^440^Senegal Airlines^^^^^https://en.wikipedia.org/wiki/Senegal_Airlines^73^en|Senegal Airlines|^^air-senegal-airlines^1^^
 air-serene-air-v1^^2017-01-29^^SEP^ER^0^SereneAir^^^^^https://en.wikipedia.org/wiki/SereneAir^379^en|SereneAir|=ur|سیرین ایئر|^ISB^air-serene-air^1^^
 air-servant-air-v1^^^^^8D^0^Servant Air^^^^^^219^en|Servant Air|^^air-servant-air^1^^
 air-servicios-aereos-andes-v1^^2014-01-01^^AND^^323^Servicios Aéreos de los Andes^Servicios Aereos de los Andes^^^^^^en|Servicios Aéreos de los Andes|=en|Andes Air|s^^air-servicios-aereos-andes^1^^


### PR DESCRIPTION
Norwegian Air Argentina has taken over IATA code `DN` from Senegal Airlines (ref. https://www.iata.org/publications/Pages/code-search.aspx) a long time ago.

I've hopefully provided the correct data in the correct files..? :)