### PR TITLE
Putting the right "location type legend" in README.md

### DIFF
--- a/data/IATA/README.md
+++ b/data/IATA/README.md
@@ -33,13 +33,13 @@ Location identifiers Web download (as of June 2010)
 
 Location type legend:
 ---------------------
-1 — Off-Line Point  
-2 — Metropolitan Area  
-3 — Airport  
-4 — Bus Station  
-5 — Railway Station  
-6 — Heliport  
-7 — Ferry Port  
+O — Off-Line Point  
+C — Metropolitan Area  
+A — Airport  
+B — Bus Station  
+R — Railway Station  
+H — Heliport  
+P — Ferry Port  
 
 Document reference: Form No. T3537-2 (30/06/05)
 


### PR DESCRIPTION
Putting the right "location type legend" as used in the latest version of the iata_airport_list_yyyymmdd.csv files in the archive folder