### PR TITLE
[Airline] Add Norwegian Air Shuttle subsidiaries

### DIFF
--- a/opentraveldata/optd_airline_best_known_so_far.csv
+++ b/opentraveldata/optd_airline_best_known_so_far.csv
@@ -730,8 +730,10 @@ air-northwestern-air-lease-v1^^^^PLR^J3^0^Northwestern Air Lease^Nw Air Lease^^^
 air-north-wright-air-v1^^^^^HW^0^North Wright Air^North Wright^^^^^en|North Wright Air|=en|North Wright|^^air-north-wright-air^1^
 air-norwegian-air-argentina-v1^^2018-10-16^^NAA^DN^323^Norwegian Air Argentina^^^^^https://en.wikipedia.org/wiki/Norwegian_Air_Argentina^en|Norwegian Air Argentina|p=en|Norwegian Air Argentina S.A.U.|=sign|NORUEGA|=zh|阿根廷挪威航空|^AEP=COR^air-norwegian-air-argentina^1^
 air-norwegian-air-international-v1^^2012-01-01^2021-10-31^IBK^D8^0^Norwegian Air International^^^^^https://en.wikipedia.org/wiki/Norwegian_Air_International^en|Norwegian Air International|^OSL^air-norwegian-air-international^1^
-air-norwegian-air-shuttle-v1^^1993-01-01^^NAX^DY^328^Norwegian Air Shuttle (NAS)^^^^^https://en.wikipedia.org/wiki/Norwegian_Air_Shuttle^en|Norwegian Air Shuttle (NAS)|^^air-norwegian-air-shuttle^1^
+air-norwegian-air-shuttle-v1^^1993-01-01^2021-10-31^NAX^DY^328^Norwegian Air Shuttle (NAS)^^^^^https://en.wikipedia.org/wiki/Norwegian_Air_Shuttle^en|Norwegian Air Shuttle (NAS)|^^air-norwegian-air-shuttle^1^
+air-norwegian-air-shuttle-aoc-v1^^2021-11-01^^NOZ^DY^0^Norwegian Air Shuttle AOC^^^^^https://en.wikipedia.org/wiki/Norwegian_Air_Shuttle^en|Norwegian Air Shuttle AOC|^^air-norwegian-air-shuttle-aoc^1^
 air-norwegian-air-sweden-ab^^^^^LE^^Norwegian Air Sweden AB^^^^^^^^air-norwegian-air-sweden-ab^1^
+air-norwegian-air-sweden-aoc-v1^^2021-11-01^^NSZ^D8^0^Norwegian Air Sweden AOC^^^^^https://en.wikipedia.org/wiki/Norwegian_Air_Sweden^en|Norwegian Air Sweden AOC|^^air-norwegian-air-sweden-aoc^1^
 air-norwegian-air-uk-v1^^2015-01-01^^NRS^DI^762^Norwegian Air UK^^^^^^en|Norwegian Air UK|^DUB^air-norwegian-air-uk^1^
 air-norwegian-long-haul-v1^^2012-01-01^^NLH^DU^0^Norwegian Long Haul^^^^^https://en.wikipedia.org/wiki/Norwegian_Long_Haul^en|Norwegian Long Haul|^OSL^air-norwegian-long-haul^1^
 air-nouvelair-v1^^1990-03-21^^LBT^BJ^796^Nouvelair^^^^^https://en.wikipedia.org/wiki/Nouvelair^en|Nouvelair|^MIR^air-nouvelair^1^


### PR DESCRIPTION
I added new subsidiaries of Norwegian Air Shuttle.
I've used a start date for new airlines just after the end of operations of previous entities to avoid overlap.

https://www.planespotters.net/airline/Norwegian-Air-Sweden-AOC
https://www.planespotters.net/airline/Norwegian-Air-Shuttle-AOC

Previous :
https://www.planespotters.net/airline/Norwegian-Air-Shuttle
https://www.planespotters.net/airline/Norwegian-Air-International