### PR TITLE
Virgin Atlantic enters Skyteam

### DIFF
--- a/opentraveldata/optd_airline_alliance_membership.csv
+++ b/opentraveldata/optd_airline_alliance_membership.csv
@@ -52,7 +52,7 @@ Skyteam^Affiliate^A5^HOP!^2013-03-31^^
 Skyteam^Affiliate^DB^HOP Brit Air^2000-06-22^2013-03-30^1
 Skyteam^Affiliate^WX^CityJet^2000-06-22^^
 Skyteam^Affiliate^YS^HOP Regional^2000-06-22^2013-03-30^1
-Skyteam^Member^AZ^Alitalia^2001-07-27^^
+Skyteam^Member^AZ^ITA Airways^2001-07-27^^
 Skyteam^Affiliate^CT^Alitalia CityLiner^2006-06-01^^
 Skyteam^Member^CI^China Airlines^2011-09-28^^
 Skyteam^Affiliate^AE^Mandarin Airlines^2011-09-28^^
@@ -72,6 +72,7 @@ Skyteam^Member^RO^TAROM^2010-06-25^^
 Skyteam^Member^VN^Vietnam Airlines^2010-06-10^^
 Skyteam^Member^MF^XiamenAir^2012-11-21^^
 Skyteam^Member^GA^Garuda Indonesia^2014-03-05^^
+Skyteam^Member^VS^Virgin Atlantic^2023-03-02^^
 Star Alliance^Member^A3^Aegean Airlines^2010-06-01^^
 Star Alliance^Affiliate^OA^Olympic Air^2013-10-01^^
 Star Alliance^Member^AC^Air Canada^1997-05-01^^


### PR DESCRIPTION
https://simpleflying.com/virgin-atlantic-join-skyteam-march-2/