### PR TITLE
Update LF airline name

### DIFF
--- a/opentraveldata/optd_airline_best_known_so_far.csv
+++ b/opentraveldata/optd_airline_best_known_so_far.csv
@@ -346,7 +346,7 @@ air-copa-airlines-v1^^1947-08-15^^CMP^CM^230^Copa Airlines^Compañía Panameña 
 air-corendon-airlines-europe-v1^^^^CXI^XR^^Corendon Airlines Europe^^^^^^^^air-corendon-airlines-europe^1^
 air-corendon-airlines-v1^^2005-04-01^^CAI^XC^0^Corendon Airlines^^^^^https://en.wikipedia.org/wiki/Corendon_Airlines^en|Corendon Airlines|p=en|Turistik Hava Tasimacilik A.S.|^AYT^air-corendon-airlines^1^
 air-corendon-dutch-airlines-v1^^^^CND^CD^0^Corendon Dutch Airlines^Seaview Air^^^^^en|Corendon Dutch Airlines|=en|Seaview Air|^^air-corendon-dutch-airlines^1^
-air-corporate-flight-management-v1^^2016-01-01^^VTE^LF^522^Corporate Flight Management^^^^^https://en.wikipedia.org/wiki/Corporate_Flight_Management^en|Corporate Flight Management|p=en|Branson Air Express|h=en|Buzz Airways|h=en|Texas Sky Airways|h=en|Appalachian Air|h=en|Contour Airlines|h=en|North Country Sky|=en|GLO Airlines|^BNA=TUP^air-corporate-flight-management^1^
+air-corporate-flight-management-v1^^2016-01-01^^VTE^LF^522^Corporate Flight Management^^^^^https://en.wikipedia.org/wiki/Corporate_Flight_Management^en|Corporate Flight Management|p=en|Branson Air Express|h=en|Buzz Airways|h=en|Texas Sky Airways|h=en|Appalachian Air|h=en|Contour Airlines|h=en|North Country Sky|=en|Contour Airlines|^BNA=TUP^air-corporate-flight-management^1^
 air-corsair-v1^^1981-05-17^^CRL^SS^923^Corsair^^^^^https://en.wikipedia.org/wiki/Corsair_International^en|Corsair|^^air-corsair^1^
 air-croatia-airlines-v1^^1989-08-20^^CTN^OU^831^Croatia Airlines^^^Member^^https://en.wikipedia.org/wiki/Croatia_Airlines^en|Croatia Airlines|^^air-croatia-airlines^1^
 air-cronos-airlines-v1^^2007-01-01^^CRA^C8^498^Cronos Airlines^^^^P^https://en.wikipedia.org/wiki/Cronos_Airlines^en|Cronos Airlines|^^air-cronos-airlines^1^


### PR DESCRIPTION
For LF airline code there are several names. 
GLO Airlines is corrected it's not operating anymore https://en.wikipedia.org/wiki/GLO_Airlines

However for this airline code there are more names that are not correct such as: 

Branson Air Express -> https://en.wikipedia.org/wiki/Branson_Air_Express
Texas Sky Airways https://www.ch-aviation.com/portal/airline/TSB
Appalachian Air https://en.wikipedia.org/wiki/Appalachian_Airlines

In my opinion we should only have Contour Airlines as the name of this airline. Can you please suggest how to correct this?

Thanks

Cristina