### PR TITLE
update GE code to Lift airline instead of transavia airways

### DIFF
--- a/opentraveldata/optd_airline_best_known_so_far.csv
+++ b/opentraveldata/optd_airline_best_known_so_far.csv
@@ -1023,7 +1023,7 @@ air-tradewind-aviation-v1^^2001-01-01^^GPD^TJ^492^Tradewind Aviation^^^^^https:/
 air-transaero-airlines-v1^^1990-01-01^^TSO^UN^670^Transaero Airlines^^^^^https://en.wikipedia.org/wiki/Transaero^en|Transaero Airlines|^^air-transaero-airlines^1^
 air-trans-air-congo-v1^^^^TSG^Q8^223^Trans Air Congo^^^^^^en|Trans Air Congo|^^air-trans-air-congo^1^
 air-transair-v1^^^^GTS^R2^^Transair^^^^^^^^air-transair^1^
-air-transasia-airways-v1^^1951-05-21^^TNA^GE^170^TransAsia Airways^^^^^https://en.wikipedia.org/wiki/TransAsia_Airways^en|TransAsia Airways|^KHH=TPE=TSA^air-transasia-airways^1^
+air-lift-airline-v1^^2020-10-01^^GBB^GE^170^Lift Airline^^^^^https://en.wikipedia.org/wiki/LIFT_(airline)^en|Lift Airline|^^air-lift-airline^1^
 air-transavia-airlines-v1^^^^TRA^HV^979^Transavia Airlines^^^^^^en|Transavia Airlines|^^air-transavia-airlines^1^
 air-transavia-denmark-v1^^^^^PH^0^Transavia Denmark^Polynesian^^^^^en|Transavia Denmark|=en|Polynesian|^^air-transavia-denmark^1^
 air-transavia-france-v1^^^^TVF^TO^0^Transavia France^President Air^^^^^en|Transavia France|=en|President Air|^^air-transavia-france^1^

--- a/opentraveldata/optd_airline_best_known_so_far.csv
+++ b/opentraveldata/optd_airline_best_known_so_far.csv
@@ -1023,6 +1023,7 @@ air-tradewind-aviation-v1^^2001-01-01^^GPD^TJ^492^Tradewind Aviation^^^^^https:/
 air-transaero-airlines-v1^^1990-01-01^^TSO^UN^670^Transaero Airlines^^^^^https://en.wikipedia.org/wiki/Transaero^en|Transaero Airlines|^^air-transaero-airlines^1^
 air-trans-air-congo-v1^^^^TSG^Q8^223^Trans Air Congo^^^^^^en|Trans Air Congo|^^air-trans-air-congo^1^
 air-transair-v1^^^^GTS^R2^^Transair^^^^^^^^air-transair^1^
+air-transasia-airways-v1^^1951-05-21^2016-22-11^TNA^GE^170^TransAsia Airways^^^^^https://en.wikipedia.org/wiki/TransAsia_Airways^en|TransAsia Airways|^KHH=TPE=TSA^air-transasia-airways^1^
 air-lift-airline-v1^^2020-10-01^^GBB^GE^170^Lift Airline^^^^^https://en.wikipedia.org/wiki/LIFT_(airline)^en|Lift Airline|^^air-lift-airline^1^
 air-transavia-airlines-v1^^^^TRA^HV^979^Transavia Airlines^^^^^^en|Transavia Airlines|^^air-transavia-airlines^1^
 air-transavia-denmark-v1^^^^^PH^0^Transavia Denmark^Polynesian^^^^^en|Transavia Denmark|=en|Polynesian|^^air-transavia-denmark^1^


### PR DESCRIPTION
The airline Transasia airways that was using the code GE seems to have ceased its activity https://en.wikipedia.org/wiki/TransAsia_Airways. Now the airline that is using this code is Lift Airline https://en.wikipedia.org/wiki/LIFT_(airline).