### PR TITLE
Update XZ from south african express to aeroitalia

### DIFF
--- a/opentraveldata/optd_airline_best_known_so_far.csv
+++ b/opentraveldata/optd_airline_best_known_so_far.csv
@@ -929,7 +929,7 @@ air-somon-air-v1^^2008-02-01^^SMR^SZ^413^Somon Air^^^^P^https://en.wikipedia.org
 air-sounds-air-v1^^1986-01-01^^SDA^S8^0^Sounds Air^^^^^https://en.wikipedia.org/wiki/Sounds_Air^en|Sounds Air|^WLG^air-sounds-air^1^
 air-south-african-airlink-v3^^2011-01-01^^LNK^4Z^749^Airlink^^^^^https://en.wikipedia.org/wiki/Airlink^en|Airlink|p=en|South African Airlink|h^^air-south-african-airlink^3^
 air-south-african-airways-v1^^1934-02-01^^SAA^SA^83^South African Airways^SAA^^Member^^https://en.wikipedia.org/wiki/South_African_Airways^en|South African Airways|=en|SAA|^^air-south-african-airways^1^
-air-aeroitalia-v1^^01-01-2022^^AEZ^XZ^^Aeroitalia^^^^^https://en.wikipedia.org/wiki/AeroItalia^en|Aeroitalia|^^air-aeroitalia^1^
+air-aeroitalia-v1^^2022-01-01^^AEZ^XZ^^Aeroitalia^^^^^https://en.wikipedia.org/wiki/AeroItalia^en|Aeroitalia|^^air-aeroitalia^1^
 air-south-african-express-v1^^1994-04-24^2020-04-28^EXY^XZ^29^South African Express^SA Express^^^^https://en.wikipedia.org/wiki/South_African_Express^en|South African Express|=en|SA Express|^^air-south-african-express^1^
 air-south-airlines-v1^^1999-04-19^^OTL^YG^233^South Airlines^^^^^https://en.wikipedia.org/wiki/South_Airlines^en|South Airlines|^^air-south-airlines^1^
 air-southern-air-charter-v1^^1998-10-01^^^PL^0^Southern Air Charter^^^^^https://en.wikipedia.org/wiki/Southern_Air_Charter^en|Southern Air Charter|^NAS^air-southern-air-charter^1^

--- a/opentraveldata/optd_airline_best_known_so_far.csv
+++ b/opentraveldata/optd_airline_best_known_so_far.csv
@@ -929,7 +929,8 @@ air-somon-air-v1^^2008-02-01^^SMR^SZ^413^Somon Air^^^^P^https://en.wikipedia.org
 air-sounds-air-v1^^1986-01-01^^SDA^S8^0^Sounds Air^^^^^https://en.wikipedia.org/wiki/Sounds_Air^en|Sounds Air|^WLG^air-sounds-air^1^
 air-south-african-airlink-v3^^2011-01-01^^LNK^4Z^749^Airlink^^^^^https://en.wikipedia.org/wiki/Airlink^en|Airlink|p=en|South African Airlink|h^^air-south-african-airlink^3^
 air-south-african-airways-v1^^1934-02-01^^SAA^SA^83^South African Airways^SAA^^Member^^https://en.wikipedia.org/wiki/South_African_Airways^en|South African Airways|=en|SAA|^^air-south-african-airways^1^
-air-south-african-express-v1^^1994-04-24^^EXY^XZ^29^South African Express^SA Express^^^^https://en.wikipedia.org/wiki/South_African_Express^en|South African Express|=en|SA Express|^^air-south-african-express^1^
+air-aeroitalia-v1^^01-01-2022^^AEZ^XZ^^Aeroitalia^^^^^https://en.wikipedia.org/wiki/AeroItalia^en|Aeroitalia|^^air-aeroitalia^1^
+air-south-african-express-v1^^1994-04-24^2020-04-28^EXY^XZ^29^South African Express^SA Express^^^^https://en.wikipedia.org/wiki/South_African_Express^en|South African Express|=en|SA Express|^^air-south-african-express^1^
 air-south-airlines-v1^^1999-04-19^^OTL^YG^233^South Airlines^^^^^https://en.wikipedia.org/wiki/South_Airlines^en|South Airlines|^^air-south-airlines^1^
 air-southern-air-charter-v1^^1998-10-01^^^PL^0^Southern Air Charter^^^^^https://en.wikipedia.org/wiki/Southern_Air_Charter^en|Southern Air Charter|^NAS^air-southern-air-charter^1^
 air-southern-air-v1^^1998-10-01^^SOO^9S^99^Southern Air^^^^^https://en.wikipedia.org/wiki/Southern_Air^en|Southern Air|^ANC=CVG=LEJ^air-southern-air^1^


### PR DESCRIPTION
The code XZ is now used by Aeroitalia since South African Express ceased its activities.