### PR TITLE
Update IATA code VF to AJet

### DIFF
--- a/opentraveldata/optd_airline_best_known_so_far.csv
+++ b/opentraveldata/optd_airline_best_known_so_far.csv
@@ -451,7 +451,7 @@ air-fly540-v1^^2006-01-01^^FFV^5H^540^Five Fourty Aviation^^^^^https://en.wikipe
 air-flyadeal-v1^^2017-09-23^^FAD^F3^0^Flyadeal^^^^^https://en.wikipedia.org/wiki/Flyadeal^ar|طيران أديل‎)|=en|Flyadeal|^JED^air-flyadeal^1^
 air-fly-africa-zimbabwe-v1^^^^FZW^ZC^^Fly Africa Zimbabwe^^^^^^^^air-fly-africa-zimbabwe^1^
 air-fly-all-ways-airlines-v1^^2016-01-22^^EDR^8W^0^Fly All Ways Airlines^^^^^https://en.wikipedia.org/wiki/Fly_All_Ways^en|Fly All Ways Airlines|^PBM^air-fly-all-ways-airlines^1^
-air-fly-armenia-airways-v1^^2016-07-01^2022-01-05^FBB^VF^^Fly Armenia Airways^^^^^^^^air-fly-armenia-airways^1^
+air-fly-armenia-airways-v1^^2020-11-26^2022-01-05^FBB^VF^^Fly Armenia Airways^^^^^^^^air-fly-armenia-airways^1^
 air-ajet-v1^^2024-03-12^^TKJ^VF^^AJet^^^^^https://en.wikipedia.org/wiki/AJet^en|AJet|^SAW^air-ajet^1^
 air-fly-art-v1^^2016-07-01^^FLB^T2^0^Fly Art^^^^^^en|Fly Art|^^air-fly-art^1^
 air-flybaghdad-v1^^2015-06-15^^FBA^IF^0^FlyBaghdad^^^^^https://en.wikipedia.org/wiki/FlyBaghdad^en|FlyBaghdad|^^air-flybaghdad^1^

--- a/opentraveldata/optd_airline_best_known_so_far.csv
+++ b/opentraveldata/optd_airline_best_known_so_far.csv
@@ -451,7 +451,8 @@ air-fly540-v1^^2006-01-01^^FFV^5H^540^Five Fourty Aviation^^^^^https://en.wikipe
 air-flyadeal-v1^^2017-09-23^^FAD^F3^0^Flyadeal^^^^^https://en.wikipedia.org/wiki/Flyadeal^ar|طيران أديل‎)|=en|Flyadeal|^JED^air-flyadeal^1^
 air-fly-africa-zimbabwe-v1^^^^FZW^ZC^^Fly Africa Zimbabwe^^^^^^^^air-fly-africa-zimbabwe^1^
 air-fly-all-ways-airlines-v1^^2016-01-22^^EDR^8W^0^Fly All Ways Airlines^^^^^https://en.wikipedia.org/wiki/Fly_All_Ways^en|Fly All Ways Airlines|^PBM^air-fly-all-ways-airlines^1^
-air-fly-armenia-airways-v1^^^^FBB^VF^^Fly Armenia Airways^^^^^^^^air-fly-armenia-airways^1^
+air-fly-armenia-airways-v1^^2016-07-01^2022-01-05^FBB^VF^^Fly Armenia Airways^^^^^^^^air-fly-armenia-airways^1^
+air-ajet-v1^^2024-03-12^^TKJ^VF^^AJet^^^^^https://en.wikipedia.org/wiki/AJet^en|AJet|^SAW^air-ajet^1^
 air-fly-art-v1^^2016-07-01^^FLB^T2^0^Fly Art^^^^^^en|Fly Art|^^air-fly-art^1^
 air-flybaghdad-v1^^2015-06-15^^FBA^IF^0^FlyBaghdad^^^^^https://en.wikipedia.org/wiki/FlyBaghdad^en|FlyBaghdad|^^air-flybaghdad^1^
 air-flybe-v1^^1979-01-01^^BEE^BE^267^Flybe^Brit Europ^^^^https://en.wikipedia.org/wiki/Flybe^en|Flybe|=en|Brit Europ|^^air-flybe^1^


### PR DESCRIPTION
The airline Fly Armenia Airways that was using the code VF ceased its activity. Now the airline that is using this IATA code is AJet (https://en.wikipedia.org/wiki/AJet / https://www.iata.org/en/publications/directories/code-search/?airline.search=AJet) 