### PR TITLE
Update_iata_code_RR_to_buzz_air

### DIFF
--- a/opentraveldata/optd_airline_best_known_so_far.csv
+++ b/opentraveldata/optd_airline_best_known_so_far.csv
@@ -857,7 +857,8 @@ air-romavia-v1^^^^^WQ^0^Romavia^^^^^^en|Romavia|^^air-romavia^1^
 air-rossiya-airlines-v1^^1992-01-01^^SDM^FV^195^Rossiya^^^^^https://en.wikipedia.org/wiki/Rossiya_%28airline%29^en|Rossiya|=en|Rossiya — Russian Airlines|^^air-rossiya-airlines^1^
 air-rotana-jet-v1^^2011-04-18^^RJD^RG^482^Rotana Jet^^^^^https://en.wikipedia.org/wiki/Rotana_Jet^en|Rotana Jet|^^air-rotana-jet^1^
 air-royal-air-charter-service-v1^^2002-08-22^^RYL^RW^0^Royal Air Charter Service^^^^^https://en.wikipedia.org/wiki/Royal_Air_Charter_Service^abbr|RACSI|=en|Royal Air Charter Service|=sign|DOUBLE GOLD|^CRK^air-royal-air-charter-service^1^
-air-royal-air-force-v1^^^^RFR^RR^0^Royal Air Force^RAF NO^^^^^en|Royal Air Force|=en|RAF NO|^^air-royal-air-force^1^
+air-royal-air-force-v1^^^2018-01-01^RFR^RR^0^Royal Air Force^RAF NO^^^^^en|Royal Air Force|=en|RAF NO|^^air-royal-air-force^1^
+air-buzz^^^^RYS^RR^0^Buzz^^2018-01-02^^^https://en.wikipedia.org/wiki/Buzz_(Ryanair)^en|Buzz|^^air-buzz^1^
 air-royal-air-maroc-express-v1^^2020-01-01^^RXP^FN^147^Royal Air Maroc Express^^^^^https://en.wikipedia.org/wiki/Royal_Air_Maroc_Express^en|Royal Air Maroc Express|^CMN^air-royal-air-maroc-express^1^
 air-royal-air-maroc-v1^^1957-01-01^^RAM^AT^147^Royal Air Maroc^^^^^https://en.wikipedia.org/wiki/Royal_Air_Maroc^abbr|RAM|=en|RAM|ps=en|Royal Air Maroc|^CMN^air-royal-air-maroc^1^
 air-royal-brunei-v1^^^^RBA^BI^672^Royal Brunei^Royalbrunei^^^^^en|Royal Brunei|=en|Royalbrunei|^^air-royal-brunei^1^


### PR DESCRIPTION
Buzz air showing as Royal Air Force, which is not a commercial airlines
https://www.buzzair.com/en/homepage/
https://en.wikipedia.org/wiki/Buzz_(Ryanair)

https://airhex.com/airlines/buzz/