### PR TITLE
Updating UN airline information

### DIFF
--- a/opentraveldata/optd_airline_best_known_so_far.csv
+++ b/opentraveldata/optd_airline_best_known_so_far.csv
@@ -1042,7 +1042,7 @@ air-titan-airways-v1^^^^AWC^ZT^0^Titan Airways^^^^^^en|Titan Airways|^^air-titan
 air-tnt-airways-v1^^^^TAY^3V^756^Tnt Airways^Viking Air^^^^^en|Tnt Airways|=en|Viking Air|^^air-tnt-airways^1^
 air-trade-air-v1^^1994-04-01^^TDR^C3^0^Trade Air^^^^^https://en.wikipedia.org/wiki/Trade_Air^en|Trade Air|^^air-trade-air^1^
 air-tradewind-aviation-v1^^2001-01-01^^GPD^TJ^492^Tradewind Aviation^^^^^https://en.wikipedia.org/wiki/Tradewind_Aviation^en|Tradewind Aviation|=en|Tradewind Shuttle|^HPN=NEV=SBH=SJU^air-tradewind-aviation^1^
-air-transaero-airlines-v1^^1990-01-01^^TSO^UN^670^Transaero Airlines^^^^^https://en.wikipedia.org/wiki/Transaero^en|Transaero Airlines|^^air-transaero-airlines^1^
+air-transaero-airlines-v1^^1990-01-01^26-10-2015^TSO^UN^670^Transaero Airlines^^^^^https://en.wikipedia.org/wiki/Transaero^en|Transaero Airlines|^^air-transaero-airlines^1^
 air-trans-air-congo-v1^^^^TSG^Q8^223^Trans Air Congo^^^^^^en|Trans Air Congo|^^air-trans-air-congo^1^
 air-transair-v1^^^^GTS^R2^^Transair^^^^^^^^air-transair^1^
 air-transasia-airways-v1^^1951-05-21^2016-11-22^TNA^GE^170^TransAsia Airways^^^^^https://en.wikipedia.org/wiki/TransAsia_Airways^en|TransAsia Airways|^KHH=TPE=TSA^air-transasia-airways^1^
@@ -1078,6 +1078,7 @@ air-um-air-v1^^^^UKM^UF^828^Um Air^^^^^^en|Um Air|^^air-um-air^1^
 air-uni-airways-v1^^^^UIA^B7^525^Uni Airways^^^^^^en|Uni Airways|^^air-uni-airways^1^
 air-united-airlines-v1^^1931-03-28^^UAL^UA^16^United Airlines^^^Member^^https://en.wikipedia.org/wiki/United_Airlines^en|United Airlines|^^air-united-airlines^1^
 air-united-airways-bangladesh-v1^^^^^4H^584^United Airways Bangladesh^Trans Pacific^^^^^en|United Airways Bangladesh|=en|Trans Pacific|^^air-united-airways-bangladesh^1^
+air-united-nigeria-airlines-v1^^2021-02-01^^UNA^UN^570^United Nigeria Airlines Company Ltd^^^^^https://en.wikipedia.org/wiki/United_Nigeria_Airlines^^ENU^air-united-nigeria-airlines^1^
 air-ups-airlines-v1^^1998-01-01^^UPS^5X^406^UPS Airlines^^^^^https://en.wikipedia.org/wiki/UPS_Airlines^en|UPS Airlines|=sign|UPS|^CGN=HKG=SDF^air-ups-airlines^1^
 air-ural-airlines-v1^^^^SVR^U6^262^Ural Airlines^^^^^https://en.wikipedia.org/wiki/Ural_Airlines^en|Ural Airlines|^MOW=SVX^air-ural-airlines^1^
 air-us-airways-v1^^1939-01-01^^AWE^US^37^US Airways^^^Member^^https://en.wikipedia.org/wiki/US_Airways^en|US Airways|^^air-us-airways^1^


### PR DESCRIPTION
UN (Transaero) has ceased operations and is now United Nigeria Airlines 