### PR TITLE
updating airline name from malindo airways to Batik Air Malaysia

### DIFF
--- a/opentraveldata/optd_airline_best_known_so_far.csv
+++ b/opentraveldata/optd_airline_best_known_so_far.csv
@@ -682,7 +682,7 @@ air-magnum-air-v1^^2012-12-14^^MSJ^M8^0^SKYJET Airlines^^^^^https://en.wikipedia
 air-mahan-airlines-v1^^^^IRM^W5^537^Mahan Airlines^^^^^^en|Mahan Airlines|^^air-mahan-airlines^1^
 air-malawian-airlines-v1^^2014-01-31^^MWI^3W^529^Malawian Airlines^^^^^https://en.wikipedia.org/wiki/Malawian_Airlines^en|Malawian Airlines|^^air-malawian-airlines^1^
 air-malaysia-airlines-v1^^1972-10-01^^MAS^MH^232^Malaysia Airlines^^^Member^^https://en.wikipedia.org/wiki/Malaysia_Airlines^en|Malaysia Airlines|^^air-malaysia-airlines^1^
-air-malindo-airways-v1^^2012-09-11^^^OD^816^Malindo Airways^^^^^https://en.wikipedia.org/wiki/Malindo_Air^en|Malindo Airways|^^air-malindo-airways^1^
+air-batik-air-malaysia-v1^^2013-03-22^^^OD^816^Batik Air Malaysia^^^^^https://fr.wikipedia.org/wiki/Batik_Air_Malaysia^en|Batik Air Malaysia|^^air-batik-air-malaysia^1^
 air-malmo-aviation-v2^^2016-03-01^^BRA^TF^276^BRA^^^^P^https://en.wikipedia.org/wiki/BRA_%28airline%29^en|BRA|ps=en|Braathens Regional Airlines|=en|Braathens Regional Aviation|=en|Malmö Aviation|h=en|Sundsvallsflyg|h=en|Kullaflyg|h=en|Kalmarflyg|h=en|Gotlandsflyg|h=en|Golden Air|h^BMA=THN^air-malmo-aviation^2^
 air-mandarin-airlines-v1^^^^MDA^AE^803^Mandarin Airlines^^^Affiliate^^^en|Mandarin Airlines|^^air-mandarin-airlines^1^
 air-mango-v1^^2006-01-01^^MNO^JE^0^Mango^^^^^https://en.wikipedia.org/wiki/Mango_%28airline%29^en|Mango|^^air-mango^1^


### PR DESCRIPTION
Upating the name from Malindo airways to Batik Air Malaysia to reflect the current naming of the airline in Amadeus