### PR TITLE
Add Finist'air airline (ICAO: FTR)

### DIFF
--- a/opentraveldata/optd_airline_best_known_so_far.csv
+++ b/opentraveldata/optd_airline_best_known_so_far.csv
@@ -450,6 +450,7 @@ air-federal-airlines-v1^^^^^7V^739^Federal Airlines^Federal Airlines^^^^^en|Fede
 air-fedex-v1^^^^FDX^FX^0^Fedex^Express Air^^^^^en|Fedex|=en|Express Air|^^air-fedex^1^
 air-felix-airways-v1^^^^FXX^FO^569^Felix Airways^^^^^^en|Felix Airways|^^air-felix-airways^1^
 air-fiji-airways-v1^^^^FJI^FJ^260^Fiji Airways^Fiji Airways^^^^^en|Fiji Airways|=en|Fiji Airways|^^air-fiji-airways^1^
+air-finistair-v1^^1981-01-01^^FTR^^^Finist'air^^^^^https://en.wikipedia.org/wiki/Finist%27air^en|Finist'air|^BES^air-finistair^1^
 air-finnair-v1^^1923-11-01^^FIN^AY^105^Finnair^^^Member^^https://en.wikipedia.org/wiki/Finnair^en|Finnair|^^air-finnair^1^
 air-first-air-v1^^^^FAB^7F^245^First Air^First Air^^^^^en|First Air|=en|First Air|^^air-first-air^1^
 air-fitsair-v1^^1997-01-02^^EXV^8D^^FitsAir^FITS Aviation (Pvt) Limited^^^^https://en.wikipedia.org/wiki/FitsAir^^^air-fitsair^1^


### PR DESCRIPTION
## Summary
- Add Finist'air, a French regional airline based at Brest Bretagne Airport (BES), to `optd_airline_best_known_so_far.csv`
- ICAO code: FTR, founded 1981
- Wikipedia: https://en.wikipedia.org/wiki/Finist%27air

Closes #274